### PR TITLE
Fix CSS not applied when using Calibre renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.11(2026-06-15)
+
+- enable local file access for calibre renderer
+
 ## v0.1.10(2026-06-14)
 
 - add integration tests for PDF outline/bookmarks (#27)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "repo-to-pdf",
-  "version": "0.1.8",
+  "version": "0.1.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "repo-to-pdf",
-      "version": "0.1.8",
+      "version": "0.1.11",
       "license": "MIT",
       "dependencies": {
         "commander": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "repo-to-pdf",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "make pdf from a repo of source code",
   "main": "src/index.js",
   "bin": {

--- a/src/render.js
+++ b/src/render.js
@@ -100,8 +100,10 @@ function sequenceRenderEbook(docFiles, options, i = 0) {
   const docFile = path.resolve(process.cwd(), docFiles[i])
   const formatFile = getFileNameExt(docFile, format)
 
+  const calibreCommonArgs = ['--allow-local-files-outside-root']
+
   const formatArgs = {
-    pdf: [
+    pdf: calibreCommonArgs.concat([
       '--pdf-add-toc',
       '--paper-size',
       'a4',
@@ -119,9 +121,9 @@ function sequenceRenderEbook(docFiles, options, i = 0) {
       '2',
       '--page-breaks-before',
       '/',
-    ],
-    mobi: ['--mobi-toc-at-start', '--output-profile', 'kindle_dx'],
-    epub: ['--epub-inline-toc', '--output-profile', 'ipad3', '--flow-size', '1000'],
+    ]),
+    mobi: calibreCommonArgs.concat(['--mobi-toc-at-start', '--output-profile', 'kindle_dx']),
+    epub: calibreCommonArgs.concat(['--epub-inline-toc', '--output-profile', 'ipad3', '--flow-size', '1000']),
   }
 
   const args = {

--- a/test/calibre-render.test.js
+++ b/test/calibre-render.test.js
@@ -1,0 +1,54 @@
+const fs = require('fs')
+const path = require('path')
+const os = require('os')
+
+jest.mock('../src/puppeteer', () => ({
+  pdf: jest.fn().mockResolvedValue(undefined),
+  close: jest.fn(),
+}))
+
+jest.mock('child_process', () => {
+  const actual = jest.requireActual('child_process')
+  return {
+    ...actual,
+    spawnSync: jest.fn(() => ({ error: null })),
+  }
+})
+
+const { spawnSync } = require('child_process')
+const { sequenceRenderEbook } = require('../src/render')
+
+describe('sequenceRenderEbook calibre options', () => {
+  let tempDir
+  let htmlFile
+  let calibrePath
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'repo-to-pdf-calibre-'))
+    htmlFile = path.join(tempDir, 'output.html')
+    fs.writeFileSync(htmlFile, '<html><body>test</body></html>')
+    calibrePath = path.join(tempDir, 'ebook-convert')
+    fs.writeFileSync(calibrePath, '')
+    fs.chmodSync(calibrePath, 0o755)
+    process.chdir(tempDir)
+  })
+
+  afterEach(() => {
+    process.chdir(path.resolve(__dirname, '..'))
+    fs.rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  it('passes --allow-local-files-outside-root to calibre', () => {
+    sequenceRenderEbook([htmlFile], {
+      outputFileName: 'output.pdf',
+      renderer: 'calibre',
+      calibrePath,
+      format: 'pdf',
+    })
+
+    expect(spawnSync).toHaveBeenCalledTimes(1)
+    const args = spawnSync.mock.calls[0][1]
+    expect(args).toContain('--allow-local-files-outside-root')
+  })
+})


### PR DESCRIPTION
## Summary

Fixes styling loss when converting HTML to PDF (or other ebook formats) with the Calibre renderer.

Generated HTML references CSS and JS in the `html5bp` folder via `file://` URLs. Calibre blocks local resources outside the HTML document root by default, so stylesheets were not embedded and the output PDF appeared as plain text.

## Fix

Pass `--allow-local-files-outside-root` to `ebook-convert` for all Calibre conversions (PDF, MOBI, EPUB). This is Calibre's equivalent of wkhtmltopdf's `--enable-local-file-access` flag.

## Testing

- Added `test/calibre-render.test.js` to verify the flag is passed to `ebook-convert`
- All existing tests pass

## Version

Bumped to v0.1.11