### PR TITLE
Fix sources excluded when highlight.js language has no aliases

### DIFF
--- a/src/repo.js
+++ b/src/repo.js
@@ -36,7 +36,7 @@ class RepoBook {
 
   registerLanguage(name, language) {
     const lang = language(hljs)
-    if (lang && lang.aliases) {
+    if (lang) {
       name = name.split('.')[0]
       if (this.whiteList) {
         if (this.whiteList.indexOf(name) > -1) {
@@ -46,16 +46,18 @@ class RepoBook {
         this.aliases[name] = name
       }
 
-      lang.aliases.map((alias) => {
-        if (this.whiteList) {
-          if (this.whiteList.indexOf(alias) > -1) {
+      if (lang.aliases) {
+        lang.aliases.map((alias) => {
+          if (this.whiteList) {
+            if (this.whiteList.indexOf(alias) > -1) {
+              this.aliases[alias] = name.split('.')[0]
+            }
+          } else {
             this.aliases[alias] = name.split('.')[0]
           }
-        } else {
-          this.aliases[alias] = name.split('.')[0]
-        }
-        return null
-      })
+          return null
+        })
+      }
     }
   }
 

--- a/test/repo.test.js
+++ b/test/repo.test.js
@@ -1,0 +1,22 @@
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+
+const RepoBook = require('../src/repo')
+
+describe('RepoBook', () => {
+  it('includes sources for languages without aliases in highlight.js', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'repo-to-pdf-'))
+    const swiftFile = path.join(tmpDir, 'example.swift')
+    fs.writeFileSync(swiftFile, 'print("hello")\n')
+
+    const repoBook = new RepoBook(tmpDir, 'test', Number.MAX_SAFE_INTEGER, null)
+    const output = repoBook.render()
+
+    expect(output).toContain('example.swift')
+    expect(output).toContain('``` swift')
+    expect(output).toContain('print("hello")')
+
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+})


### PR DESCRIPTION
## Problem

`RepoBook.registerLanguage()` only registered highlight.js languages when `lang.aliases` was defined. About 89 languages (e.g. Swift, Dart, Scala, Lua) have no `aliases` property, so files with those extensions were filtered out during PDF generation.

## Solution

- Register the language name whenever highlight.js returns a valid language definition.
- Map optional `aliases` only when they are present.

## Testing

Added `test/repo.test.js` with a Swift file fixture (a language without aliases) and verified it is included in rendered output.

