### PR TITLE
Add dependency-free native PDF generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - add `native` renderer: a dependency-free, highly efficient PDF generator that reads source code and writes PDF directly (no puppeteer/headless browser)
   - imitates the HTML/GitHub styling with `highlight.js` syntax highlighting
   - embeds a PDF outline (table of contents) and uses only built-in fonts to keep files small
-  - made the default renderer
+  - available via `-r native`; `node` (puppeteer) remains the default renderer
 
 ## v0.1.12(2026-06-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # Changelog
 
-## Unreleased
+## v0.2.0(2026-06-17) - unreleased
 
 - add `native` renderer: a dependency-free, highly efficient PDF generator that reads source code and writes PDF directly (no puppeteer/headless browser)
   - imitates the HTML/GitHub styling with `highlight.js` syntax highlighting
   - embeds a PDF outline (table of contents) and uses only built-in fonts to keep files small
-  - available via `-r native`; `node` (puppeteer) remains the default renderer
+  - available via `-r native`
 
 ## v0.1.12(2026-06-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- add `native` renderer: a dependency-free, highly efficient PDF generator that reads source code and writes PDF directly (no puppeteer/headless browser)
+  - imitates the HTML/GitHub styling with `highlight.js` syntax highlighting
+  - embeds a PDF outline (table of contents) and uses only built-in fonts to keep files small
+  - made the default renderer
+
 ## v0.1.12(2026-06-16)
 
 - fix markdown image display

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ const { generateEbook } = require('repo-to-pdf')
 /**
  * @typedef Options
  * @type {object}
- * @property {string} renderer - [native|node|calibre|wkhtmltopdf] native (built-in, dependency-free, default), node (puppeteer), calibre or wkhtmltopdf
+ * @property {string} renderer - [native|node|calibre|wkhtmltopdf] node (puppeteer, default), native (built-in, dependency-free), calibre or wkhtmltopdf
  * @property {string} calibrePath - path of calibre's ebook-convert
  * @property {string} pdf_size - pdf size limit, in bytes
  * @property {string} white_list - list of file extensions to be included, separate by ','
@@ -45,17 +45,17 @@ const { generateEbook } = require('repo-to-pdf')
  * @param {string} title - title in ebook file
  * @param {Options} options
  */
-generateEbook('./', 'test.pdf', 'repo-test', { renderer: 'native', pdf_size: 3 * 0.8 * 1000 * 1000, format: 'pdf', device: 'desktop', outline: true })
+generateEbook('./', 'test.pdf', 'repo-test', { renderer: 'node', pdf_size: 3 * 0.8 * 1000 * 1000, format: 'pdf', device: 'desktop', outline: true })
 ```
 
 ### Renderers
 
-| renderer       | engine                         | deps                | speed     | output         |
-| -------------- | ------------------------------ | ------------------- | --------- | -------------- |
-| `native`       | built-in PDF writer (default)  | none                | very fast | pdf            |
-| `node`         | puppeteer (headless Chrome)    | puppeteer + Chrome  | slow      | pdf            |
-| `wkhtmltopdf`  | wkhtmltopdf binary             | wkhtmltopdf         | medium    | pdf            |
-| `calibre`      | calibre `ebook-convert`        | calibre             | medium    | pdf, mobi, epub|
+| renderer      | engine                               | deps               | speed     | output          |
+| ------------- | ------------------------------------ | ------------------ | --------- | --------------- |
+| `node`        | puppeteer (headless Chrome, default) | puppeteer + Chrome | slow      | pdf             |
+| `native`      | built-in PDF writer                  | none               | very fast | pdf             |
+| `wkhtmltopdf` | wkhtmltopdf binary                   | wkhtmltopdf        | medium    | pdf             |
+| `calibre`     | calibre `ebook-convert`              | calibre            | medium    | pdf, mobi, epub |
 
 The `native` renderer reads the source code and writes a PDF directly, with no
 external dependencies or headless browser. It imitates the GitHub/HTML styling,
@@ -85,8 +85,8 @@ pdf file size limit, in MB, default 10 MB
 # npx repo-to-pdf ../repo -s 10
 
 -r, --renderer [native|node|calibre|wkhtmltopdf]
-choose the render engine (default native). native is the built-in dependency-free
-PDF generator; node uses puppeteer; calibre outputs pdf, mobi, epub
+choose the render engine (default node). node uses puppeteer; native is the
+built-in dependency-free PDF generator; calibre outputs pdf, mobi, epub
 # npx repo-to-pdf ../repo -r native
 # npx repo-to-pdf ../repo -r calibre
 
@@ -130,12 +130,13 @@ cd test/data && wget https://github.com/redis/redis/archive/refs/tags/7.0.0.zip 
 on M1 Macbook Air
 
 ```bash
-# native (default): no headless browser, single process
+# node (default): puppeteer / headless Chrome
 time npx repo-to-pdf ./test/data/redis-7.0.0/src -s 3
-# a few seconds, minimal CPU
-
-time npx repo-to-pdf ./test/data/redis-7.0.0/src -s 3 -r node
 2.09s user 0.36s system 2% cpu 1:42.14 total
+
+# native: no headless browser, single process, much faster and lighter
+time npx repo-to-pdf ./test/data/redis-7.0.0/src -s 3 -r native
+# a few seconds, minimal CPU
 
 time npx repo-to-pdf ./test/data/redis-7.0.0/src -s 3 -r wkhtmltopdf
 43.78s user 0.84s system 93% cpu 47.787 total

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ const { generateEbook } = require('repo-to-pdf')
 /**
  * @typedef Options
  * @type {object}
- * @property {string} renderer - [node|calibre|wkhtmltopdf] can be either node, calibre and wkhtmltopdf
+ * @property {string} renderer - [native|node|calibre|wkhtmltopdf] native (built-in, dependency-free, default), node (puppeteer), calibre or wkhtmltopdf
  * @property {string} calibrePath - path of calibre's ebook-convert
  * @property {string} pdf_size - pdf size limit, in bytes
  * @property {string} white_list - list of file extensions to be included, separate by ','
@@ -45,8 +45,25 @@ const { generateEbook } = require('repo-to-pdf')
  * @param {string} title - title in ebook file
  * @param {Options} options
  */
-generateEbook('./', 'test.pdf', 'repo-test', { renderer: 'node', pdf_size: 3 * 0.8 * 1000 * 1000, format: 'pdf', device: 'desktop', outline: true })
+generateEbook('./', 'test.pdf', 'repo-test', { renderer: 'native', pdf_size: 3 * 0.8 * 1000 * 1000, format: 'pdf', device: 'desktop', outline: true })
 ```
+
+### Renderers
+
+| renderer       | engine                         | deps                | speed     | output         |
+| -------------- | ------------------------------ | ------------------- | --------- | -------------- |
+| `native`       | built-in PDF writer (default)  | none                | very fast | pdf            |
+| `node`         | puppeteer (headless Chrome)    | puppeteer + Chrome  | slow      | pdf            |
+| `wkhtmltopdf`  | wkhtmltopdf binary             | wkhtmltopdf         | medium    | pdf            |
+| `calibre`      | calibre `ebook-convert`        | calibre             | medium    | pdf, mobi, epub|
+
+The `native` renderer reads the source code and writes a PDF directly, with no
+external dependencies or headless browser. It imitates the GitHub/HTML styling,
+applies `highlight.js` syntax highlighting, embeds PDF bookmarks (table of
+contents) and only references the built-in PDF fonts so output files stay
+small. Because it relies on the standard fonts, glyphs outside WinAnsi (e.g.
+CJK) are substituted with a placeholder; use the `node` renderer if you need
+full Unicode coverage.
 
 ### Command Line Options
 
@@ -67,8 +84,10 @@ file format white list, split by ","
 pdf file size limit, in MB, default 10 MB
 # npx repo-to-pdf ../repo -s 10
 
--r, --renderer [node|calibre|wkhtmltopdf]
-use either node(relaxedjs) or calibre to render ebook, node outputs pdf, calibre outputs pdf, mobi, epub
+-r, --renderer [native|node|calibre|wkhtmltopdf]
+choose the render engine (default native). native is the built-in dependency-free
+PDF generator; node uses puppeteer; calibre outputs pdf, mobi, epub
+# npx repo-to-pdf ../repo -r native
 # npx repo-to-pdf ../repo -r calibre
 
 -f, --format [pdf|mobi|epub]
@@ -111,7 +130,11 @@ cd test/data && wget https://github.com/redis/redis/archive/refs/tags/7.0.0.zip 
 on M1 Macbook Air
 
 ```bash
+# native (default): no headless browser, single process
 time npx repo-to-pdf ./test/data/redis-7.0.0/src -s 3
+# a few seconds, minimal CPU
+
+time npx repo-to-pdf ./test/data/redis-7.0.0/src -s 3 -r node
 2.09s user 0.36s system 2% cpu 1:42.14 total
 
 time npx repo-to-pdf ./test/data/redis-7.0.0/src -s 3 -r wkhtmltopdf

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "test": "npm run clean:test && jest --forceExit; status=$?; npm run clean:test; exit $status",
     "test:nocleanup": "jest --forceExit",
-    "clean:test": "rm -f self*.html self*.pdf self*.mobi self*.epub redis*.html redis*.pdf redis*.mobi redis*.epub",
+    "clean:test": "rm -f self*.html self*.pdf self*.mobi self*.epub redis*.html redis*.pdf redis*.mobi redis*.epub native*.html native*.pdf",
     "format": "eslint \"**/*.js\" --fix && prettier \"**/*.{js,json,md}\" --write",
     "format:staged": "eslint \"**/*.js\" --fix && pretty-quick --staged --verbose --pattern \"**/*.{js,json,md}\"",
     "format:check": "eslint \"**/*.js\" && prettier --check \"**/*.{js,json,md}\""

--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -15,7 +15,7 @@ program
   .option('-t, --title [name]', 'title')
   .option('-w, --whitelist [wlist]', 'file format white list, split by ,')
   .option('-s, --size [size]', 'pdf file size limit, in Mb')
-  .option('-r, --renderer <engine>', '[native|node|wkhtmltopdf|calibre] native(built-in, no deps), node(puppeteer), wkhtmltopdf or calibre', 'native')
+  .option('-r, --renderer <engine>', '[native|node|wkhtmltopdf|calibre] native(built-in, no deps), node(puppeteer, default), wkhtmltopdf or calibre', 'node')
   .option('-f, --format <ext>', 'output format, pdf|mobi|epub', 'pdf')
   .option('--no-outline', 'disable PDF outlines/bookmarks (default enabled)')
   .option('-p, --concurrency <num>', 'number of parallel Puppeteer PDF render jobs')

--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -15,7 +15,7 @@ program
   .option('-t, --title [name]', 'title')
   .option('-w, --whitelist [wlist]', 'file format white list, split by ,')
   .option('-s, --size [size]', 'pdf file size limit, in Mb')
-  .option('-r, --renderer <engine>', '[node|wkhtmltopdf|calibre] use node(puppeteer), wkhtmltopdf or calibre to render pdf', 'node')
+  .option('-r, --renderer <engine>', '[native|node|wkhtmltopdf|calibre] native(built-in, no deps), node(puppeteer), wkhtmltopdf or calibre', 'native')
   .option('-f, --format <ext>', 'output format, pdf|mobi|epub', 'pdf')
   .option('--no-outline', 'disable PDF outlines/bookmarks (default enabled)')
   .option('-p, --concurrency <num>', 'number of parallel Puppeteer PDF render jobs')

--- a/src/html.js
+++ b/src/html.js
@@ -7,6 +7,7 @@ const hljs = require('highlight.js')
 
 const RepoBook = require('./repo')
 const { sequenceRenderEbook, sequenceRenderPDF, renderPDF } = require('./render')
+const { renderNativePart } = require('./native')
 const { getFileName, getFileNameExt } = require('./utils')
 
 function getRemarkableParser() {
@@ -111,7 +112,7 @@ function checkOptions(options) {
     options.baseUrl = path.resolve(__dirname, '../html5bp')
   }
 
-  if (options.format !== 'pdf' && options.renderer === 'node') {
+  if (options.format !== 'pdf' && (options.renderer === 'node' || options.renderer === 'native')) {
     console.log(`Try to create ${options.format}, use renderer Calibre.`)
     options.renderer = 'calibre'
   }
@@ -139,7 +140,7 @@ function checkOptions(options) {
 /**
  * @typedef Options
  * @type {object}
- * @property {string} renderer - [node|calibre|wkhtmltopdf] can be either node, calibre and wkhtmltopdf
+ * @property {string} renderer - [native|node|calibre|wkhtmltopdf] native (built-in, dependency-free, default), node (puppeteer), calibre or wkhtmltopdf
  * @property {string} calibrePath - path of calibre's ebook-convert
  * @property {string} pdf_size - pdf size limit, in bytes
  * @property {string} white_list - list of file extensions to be included, separate by ','
@@ -157,7 +158,7 @@ function checkOptions(options) {
  * @param {string} title - title in ebook file
  * @param {Options} options
  */
-async function generateEbook(inputFolder, outputFile, title, options = { renderer: 'node' }) {
+async function generateEbook(inputFolder, outputFile, title, options = { renderer: 'native' }) {
   if (!checkOptions(options)) {
     return
   }
@@ -172,13 +173,24 @@ async function generateEbook(inputFolder, outputFile, title, options = { rendere
   options.inputFolder = inputFolder
   options.outputFile = outputFile
 
+  const isNative = renderer === 'native'
+  const startTs = Date.now()
   const outputFiles = []
   while (repoBook.hasNextPart()) {
     const mdString = repoBook.render()
     if (!mdString) {
-      console.log('Nothing to generate.')
+      if (outputFiles.length === 0) {
+        console.log('Nothing to generate.')
+      }
       return
     }
+
+    if (isNative) {
+      const outputFile = renderNativePart(mdString, repoBook, options)
+      outputFiles.push(outputFile)
+      continue
+    }
+
     let outputFile = null
     outputFile = getHTMLFiles(mdString, repoBook, options)
 
@@ -190,6 +202,9 @@ async function generateEbook(inputFolder, outputFile, title, options = { rendere
   }
   if (renderer === 'calibre') {
     sequenceRenderEbook(outputFiles, options)
+  } else if (renderer === 'native') {
+    outputFiles.forEach((file) => console.log(`${file} created.`))
+    console.log(`${outputFileName} created in ${(Date.now() - startTs) / 1000} seconds.`)
   } else if (renderer === 'node') {
     await sequenceRenderPDF(outputFiles, options)
   } else if (renderer === 'wkhtmltopdf') {

--- a/src/html.js
+++ b/src/html.js
@@ -140,7 +140,7 @@ function checkOptions(options) {
 /**
  * @typedef Options
  * @type {object}
- * @property {string} renderer - [native|node|calibre|wkhtmltopdf] native (built-in, dependency-free, default), node (puppeteer), calibre or wkhtmltopdf
+ * @property {string} renderer - [native|node|calibre|wkhtmltopdf] node (puppeteer, default), native (built-in, dependency-free), calibre or wkhtmltopdf
  * @property {string} calibrePath - path of calibre's ebook-convert
  * @property {string} pdf_size - pdf size limit, in bytes
  * @property {string} white_list - list of file extensions to be included, separate by ','
@@ -158,7 +158,7 @@ function checkOptions(options) {
  * @param {string} title - title in ebook file
  * @param {Options} options
  */
-async function generateEbook(inputFolder, outputFile, title, options = { renderer: 'native' }) {
+async function generateEbook(inputFolder, outputFile, title, options = { renderer: 'node' }) {
   if (!checkOptions(options)) {
     return
   }

--- a/src/native.js
+++ b/src/native.js
@@ -1,0 +1,29 @@
+const fs = require('fs')
+const path = require('path')
+
+const { renderMarkdownToPdf } = require('./pdf/layout')
+const { getFileName, getFileNameExt } = require('./utils')
+
+// Resolve the output PDF path for the current RepoBook part, mirroring the
+// naming scheme used by the HTML pipeline (book.pdf, book-1.pdf, ...).
+function getNativeOutputFile(repoBook, options) {
+  const { outputFileName, inputFolder } = options
+  const pdfName = getFileNameExt(outputFileName, 'pdf') || getFileName(inputFolder) + '.pdf'
+  let outputFile = path.resolve(process.cwd(), pdfName)
+
+  if (!repoBook.hasSingleFile()) {
+    outputFile = outputFile.replace('.pdf', '-' + repoBook.currentPart() + '.pdf')
+  }
+  return outputFile
+}
+
+// Render one RepoBook part (a markdown string) straight to a PDF file using the
+// dependency-free generator.
+function renderNativePart(mdString, repoBook, options) {
+  const outputFile = getNativeOutputFile(repoBook, options)
+  const buffer = renderMarkdownToPdf(mdString, { outline: options.outline !== false })
+  fs.writeFileSync(outputFile, buffer)
+  return outputFile
+}
+
+module.exports = { renderNativePart }

--- a/src/pdf/document.js
+++ b/src/pdf/document.js
@@ -1,0 +1,170 @@
+const zlib = require('zlib')
+
+const { FONT_NAMES, FONT_KEYS, encodePdfString } = require('./fonts')
+
+// Minimal PDF writer. Produces a single-file PDF with the base-14 fonts,
+// FlateDecode-compressed content streams and an optional document outline
+// (bookmarks). No external dependencies are used.
+class PDFDocument {
+  constructor({ width = 612, height = 792 } = {}) {
+    this.width = width
+    this.height = height
+    this.objects = [] // index 0 => object id 1
+    this.pages = [] // { pageId, contentId }
+
+    this.fontIds = {}
+    this._createFonts()
+    this._resourcesId = this._alloc()
+  }
+
+  _alloc() {
+    this.objects.push(null)
+    return this.objects.length
+  }
+
+  _set(id, body) {
+    this.objects[id - 1] = Buffer.isBuffer(body) ? body : Buffer.from(body, 'latin1')
+  }
+
+  _createFonts() {
+    for (const key of Object.keys(FONT_NAMES)) {
+      const id = this._alloc()
+      this.fontIds[key] = id
+      this._set(id, `<< /Type /Font /Subtype /Type1 /BaseFont /${FONT_NAMES[key]} /Encoding /WinAnsiEncoding >>`)
+    }
+  }
+
+  _resourcesBody() {
+    const fontEntries = Object.keys(FONT_KEYS)
+      .map((key) => `/${FONT_KEYS[key]} ${this.fontIds[key]} 0 R`)
+      .join(' ')
+    return `<< /Font << ${fontEntries} >> >>`
+  }
+
+  // Add a page whose content stream is the given (uncompressed) string.
+  addPage(content) {
+    const pageId = this._alloc()
+    const contentId = this._alloc()
+
+    const raw = Buffer.from(content, 'latin1')
+    const compressed = zlib.deflateSync(raw, { level: 9 })
+    const stream = Buffer.concat([Buffer.from(`<< /Length ${compressed.length} /Filter /FlateDecode >>\nstream\n`, 'latin1'), compressed, Buffer.from('\nendstream', 'latin1')])
+    this._set(contentId, stream)
+
+    this.pages.push({ pageId, contentId })
+    return pageId
+  }
+
+  // outline: tree of { title, pageIndex, y, children }
+  build(outline) {
+    const pagesId = this._alloc()
+
+    this.pages.forEach(({ pageId, contentId }) => {
+      this._set(pageId, `<< /Type /Page /Parent ${pagesId} 0 R /MediaBox [0 0 ${this.width} ${this.height}] ` + `/Resources ${this._resourcesId} 0 R /Contents ${contentId} 0 R >>`)
+    })
+
+    this._set(this._resourcesId, this._resourcesBody())
+
+    const kids = this.pages.map(({ pageId }) => `${pageId} 0 R`).join(' ')
+    this._set(pagesId, `<< /Type /Pages /Count ${this.pages.length} /Kids [${kids}] >>`)
+
+    let outlineId = null
+    if (outline && outline.length > 0) {
+      outlineId = this._buildOutline(outline)
+    }
+
+    const catalogId = this._alloc()
+    let catalog = `<< /Type /Catalog /Pages ${pagesId} 0 R`
+    if (outlineId) {
+      catalog += ` /Outlines ${outlineId} 0 R /PageMode /UseOutlines`
+    }
+    catalog += ' >>'
+    this._set(catalogId, catalog)
+
+    return this._serialize(catalogId)
+  }
+
+  _buildOutline(tree) {
+    const outlineId = this._alloc()
+
+    // Pre-allocate an id for every node so siblings/parents can reference it.
+    const assignIds = (nodes) => {
+      nodes.forEach((node) => {
+        node._id = this._alloc()
+        if (node.children && node.children.length) {
+          assignIds(node.children)
+        }
+      })
+    }
+    assignIds(tree)
+
+    let totalVisible = 0
+
+    const writeNodes = (nodes, parentId) => {
+      let descendants = 0
+      nodes.forEach((node, index) => {
+        const pageId = this.pages[node.pageIndex] ? this.pages[node.pageIndex].pageId : this.pages[0].pageId
+        const prev = index > 0 ? `${nodes[index - 1]._id} 0 R` : null
+        const next = index < nodes.length - 1 ? `${nodes[index + 1]._id} 0 R` : null
+
+        let dict = `<< /Title (${encodePdfString(node.title).toString('latin1')}) /Parent ${parentId} 0 R`
+        if (prev) {
+          dict += ` /Prev ${prev}`
+        }
+        if (next) {
+          dict += ` /Next ${next}`
+        }
+
+        let childCount = 0
+        if (node.children && node.children.length) {
+          childCount = writeNodes(node.children, node._id)
+          dict += ` /First ${node.children[0]._id} 0 R /Last ${node.children[node.children.length - 1]._id} 0 R /Count ${childCount}`
+        }
+
+        const y = Math.round(node.y * 100) / 100
+        dict += ` /Dest [${pageId} 0 R /XYZ 0 ${y} null] >>`
+        this._set(node._id, dict)
+
+        descendants += 1 + childCount
+      })
+      return descendants
+    }
+
+    totalVisible = writeNodes(tree, outlineId)
+
+    this._set(outlineId, `<< /Type /Outlines /First ${tree[0]._id} 0 R /Last ${tree[tree.length - 1]._id} 0 R /Count ${totalVisible} >>`)
+
+    return outlineId
+  }
+
+  _serialize(catalogId) {
+    const header = Buffer.from('%PDF-1.4\n%\xff\xff\xff\xff\n', 'latin1')
+    const chunks = [header]
+    const offsets = new Array(this.objects.length + 1).fill(0)
+    let position = header.length
+
+    for (let i = 0; i < this.objects.length; i++) {
+      const id = i + 1
+      const body = this.objects[i] || Buffer.from('<< >>', 'latin1')
+      offsets[id] = position
+      const prefix = Buffer.from(`${id} 0 obj\n`, 'latin1')
+      const suffix = Buffer.from('\nendobj\n', 'latin1')
+      const objBuf = Buffer.concat([prefix, body, suffix])
+      chunks.push(objBuf)
+      position += objBuf.length
+    }
+
+    const xrefOffset = position
+    const count = this.objects.length + 1
+    let xref = `xref\n0 ${count}\n0000000000 65535 f \n`
+    for (let id = 1; id < count; id++) {
+      xref += `${String(offsets[id]).padStart(10, '0')} 00000 n \n`
+    }
+    xref += `trailer\n<< /Size ${count} /Root ${catalogId} 0 R >>\nstartxref\n${xrefOffset}\n%%EOF\n`
+    chunks.push(Buffer.from(xref, 'latin1'))
+
+    return Buffer.concat(chunks)
+  }
+}
+
+module.exports = PDFDocument

--- a/src/pdf/fonts.js
+++ b/src/pdf/fonts.js
@@ -1,0 +1,161 @@
+// Standard PDF (base-14) font metrics and WinAnsi text encoding.
+//
+// Using the built-in fonts keeps generated PDFs tiny because the glyph
+// programs never have to be embedded. The trade-off is that only characters
+// available in WinAnsiEncoding can be rendered; anything outside that range is
+// substituted with a placeholder so the byte stream stays valid.
+
+// AFM advance widths (per 1000 em) for the ASCII range 32..126.
+// prettier-ignore
+const HELVETICA = {
+  32:278, 33:278, 34:355, 35:556, 36:556, 37:889, 38:667, 39:191, 40:333, 41:333, 42:389, 43:584, 44:278, 45:333, 46:278, 47:278,
+  48:556, 49:556, 50:556, 51:556, 52:556, 53:556, 54:556, 55:556, 56:556, 57:556,
+  58:278, 59:278, 60:584, 61:584, 62:584, 63:556, 64:1015,
+  65:667, 66:667, 67:722, 68:722, 69:667, 70:611, 71:778, 72:722, 73:278, 74:500, 75:667, 76:556, 77:833, 78:722, 79:778, 80:667, 81:778, 82:722, 83:667, 84:611, 85:722, 86:667, 87:944, 88:667, 89:667, 90:611,
+  91:278, 92:278, 93:278, 94:469, 95:556, 96:333,
+  97:556, 98:556, 99:500, 100:556, 101:556, 102:278, 103:556, 104:556, 105:222, 106:222, 107:500, 108:222, 109:833, 110:556, 111:556, 112:556, 113:556, 114:333, 115:500, 116:278, 117:556, 118:500, 119:722, 120:500, 121:500, 122:500,
+  123:334, 124:260, 125:334, 126:584,
+}
+
+// prettier-ignore
+const HELVETICA_BOLD = {
+  32:278, 33:333, 34:474, 35:556, 36:556, 37:889, 38:722, 39:238, 40:333, 41:333, 42:389, 43:584, 44:278, 45:333, 46:278, 47:278,
+  48:556, 49:556, 50:556, 51:556, 52:556, 53:556, 54:556, 55:556, 56:556, 57:556,
+  58:333, 59:333, 60:584, 61:584, 62:584, 63:611, 64:975,
+  65:722, 66:722, 67:722, 68:722, 69:667, 70:611, 71:778, 72:722, 73:278, 74:556, 75:722, 76:611, 77:833, 78:722, 79:778, 80:667, 81:778, 82:722, 83:667, 84:611, 85:722, 86:667, 87:944, 88:667, 89:667, 90:611,
+  91:333, 92:278, 93:333, 94:584, 95:556, 96:333,
+  97:556, 98:611, 99:556, 100:611, 101:556, 102:333, 103:611, 104:611, 105:278, 106:278, 107:556, 108:278, 109:889, 110:611, 111:611, 112:611, 113:611, 114:389, 115:556, 116:333, 117:611, 118:556, 119:778, 120:556, 121:556, 122:500,
+  123:389, 124:280, 125:389, 126:584,
+}
+
+const DEFAULT_LATIN_WIDTH = 556
+const DEFAULT_BOLD_LATIN_WIDTH = 611
+const COURIER_WIDTH = 600
+
+// PDF standard font resource names. The fourth combination (bold + italic) is
+// included so emphasised prose keeps the correct weight.
+const FONT_NAMES = {
+  body: 'Helvetica',
+  bodyBold: 'Helvetica-Bold',
+  bodyItalic: 'Helvetica-Oblique',
+  bodyBoldItalic: 'Helvetica-BoldOblique',
+  mono: 'Courier',
+  monoBold: 'Courier-Bold',
+  monoItalic: 'Courier-Oblique',
+}
+
+// Resource identifiers used inside page /Font dictionaries.
+const FONT_KEYS = {
+  body: 'F1',
+  bodyBold: 'F2',
+  bodyItalic: 'F3',
+  bodyBoldItalic: 'F4',
+  mono: 'F5',
+  monoBold: 'F6',
+  monoItalic: 'F7',
+}
+
+// Map a Unicode code point onto its WinAnsiEncoding byte. Only the printable
+// subset is handled; unsupported characters fall back to '?'.
+const QUESTION_MARK = 0x3f
+
+// A handful of common Windows-1252 punctuation glyphs that live in 0x80..0x9F.
+const CP1252_EXTRAS = {
+  0x20ac: 0x80, // €
+  0x201a: 0x82,
+  0x0192: 0x83,
+  0x201e: 0x84,
+  0x2026: 0x85, // …
+  0x2020: 0x86,
+  0x2021: 0x87,
+  0x02c6: 0x88,
+  0x2030: 0x89,
+  0x0160: 0x8a,
+  0x2039: 0x8b,
+  0x0152: 0x8c, // Œ
+  0x017d: 0x8e,
+  0x2018: 0x91, // ‘
+  0x2019: 0x92, // ’
+  0x201c: 0x93, // “
+  0x201d: 0x94, // ”
+  0x2022: 0x95, // •
+  0x2013: 0x96, // –
+  0x2014: 0x97, // —
+  0x02dc: 0x98,
+  0x2122: 0x99, // ™
+  0x0161: 0x9a,
+  0x203a: 0x9b,
+  0x0153: 0x9c, // œ
+  0x017e: 0x9e,
+  0x0178: 0x9f,
+}
+
+function toWinAnsiByte(codePoint) {
+  if (codePoint === 0x09) {
+    return 0x20 // tabs are expanded before encoding, treat stragglers as space
+  }
+  if (codePoint >= 0x20 && codePoint <= 0x7e) {
+    return codePoint
+  }
+  if (codePoint >= 0xa0 && codePoint <= 0xff) {
+    return codePoint
+  }
+  if (Object.prototype.hasOwnProperty.call(CP1252_EXTRAS, codePoint)) {
+    return CP1252_EXTRAS[codePoint]
+  }
+  return QUESTION_MARK
+}
+
+// Encode a JS string into a WinAnsi byte buffer, escaping PDF string syntax.
+function encodePdfString(str) {
+  const bytes = []
+  for (const ch of str) {
+    const byte = toWinAnsiByte(ch.codePointAt(0))
+    if (byte === 0x28 || byte === 0x29 || byte === 0x5c) {
+      bytes.push(0x5c) // backslash escape for ( ) \
+    }
+    bytes.push(byte)
+  }
+  return Buffer.from(bytes)
+}
+
+function widthTableFor(fontKey) {
+  switch (fontKey) {
+    case 'bodyBold':
+    case 'bodyBoldItalic':
+      return { table: HELVETICA_BOLD, fallback: DEFAULT_BOLD_LATIN_WIDTH, mono: false }
+    case 'body':
+    case 'bodyItalic':
+      return { table: HELVETICA, fallback: DEFAULT_LATIN_WIDTH, mono: false }
+    default:
+      return { table: null, fallback: COURIER_WIDTH, mono: true }
+  }
+}
+
+// Width of a single character (in points) for the given font key and size.
+function charWidth(ch, fontKey, fontSize) {
+  const { table, fallback, mono } = widthTableFor(fontKey)
+  if (mono) {
+    return (COURIER_WIDTH / 1000) * fontSize
+  }
+  const code = toWinAnsiByte(ch.codePointAt(0))
+  const units = (table && table[code]) || fallback
+  return (units / 1000) * fontSize
+}
+
+// Width of a string (in points) for the given font key and size.
+function measureText(str, fontKey, fontSize) {
+  let total = 0
+  for (const ch of str) {
+    total += charWidth(ch, fontKey, fontSize)
+  }
+  return total
+}
+
+module.exports = {
+  FONT_NAMES,
+  FONT_KEYS,
+  encodePdfString,
+  charWidth,
+  measureText,
+}

--- a/src/pdf/highlighter.js
+++ b/src/pdf/highlighter.js
@@ -1,0 +1,142 @@
+const hljs = require('highlight.js')
+
+// Token colours mirror the Visual Studio theme shipped in html5bp/css/vs.css so
+// the native renderer matches the existing HTML output.
+const CLASS_COLORS = {
+  comment: '#008000',
+  quote: '#008000',
+  variable: '#008000',
+  keyword: '#0000ff',
+  'selector-tag': '#0000ff',
+  built_in: '#0000ff',
+  name: '#0000ff',
+  tag: '#0000ff',
+  string: '#a31515',
+  title: '#a31515',
+  section: '#a31515',
+  attribute: '#a31515',
+  literal: '#a31515',
+  'template-tag': '#a31515',
+  'template-variable': '#a31515',
+  type: '#a31515',
+  addition: '#a31515',
+  deletion: '#2b91af',
+  'selector-attr': '#2b91af',
+  'selector-pseudo': '#2b91af',
+  meta: '#2b91af',
+  doctag: '#808080',
+  attr: '#ff0000',
+  symbol: '#00b0e8',
+  bullet: '#00b0e8',
+  link: '#00b0e8',
+}
+
+const ENTITIES = {
+  '&amp;': '&',
+  '&lt;': '<',
+  '&gt;': '>',
+  '&quot;': '"',
+  '&#x27;': "'",
+  '&#39;': "'",
+  '&#x2F;': '/',
+  '&nbsp;': ' ',
+}
+
+function decodeEntities(text) {
+  return text.replace(/&(?:amp|lt|gt|quot|nbsp|#x27|#39|#x2F);/g, (match) => ENTITIES[match] || match).replace(/&#(\d+);/g, (_m, code) => String.fromCodePoint(Number(code)))
+}
+
+// Resolve the visual style for the current span stack. Inner spans win for the
+// colour; bold/italic accumulate from any level.
+function resolveStyle(stack) {
+  let color = null
+  let bold = false
+  let italic = false
+
+  for (const classes of stack) {
+    for (const cls of classes) {
+      if (cls === 'strong') {
+        bold = true
+      } else if (cls === 'emphasis') {
+        italic = true
+      }
+    }
+  }
+
+  for (let i = stack.length - 1; i >= 0 && color === null; i--) {
+    for (const cls of stack[i]) {
+      if (CLASS_COLORS[cls]) {
+        color = CLASS_COLORS[cls]
+        break
+      }
+    }
+  }
+
+  return { color, bold, italic }
+}
+
+const TOKEN_PATTERN = /<span class="([^"]*)">|<\/span>|([^<]+)/g
+
+// Flatten highlight.js HTML into a list of { text, color, bold, italic }
+// segments. Segments may contain newlines; callers split them per line.
+function htmlToSegments(html) {
+  const segments = []
+  const stack = []
+  let match
+
+  TOKEN_PATTERN.lastIndex = 0
+  while ((match = TOKEN_PATTERN.exec(html)) !== null) {
+    if (match[1] !== undefined) {
+      const classes = match[1]
+        .split(/\s+/)
+        .filter(Boolean)
+        .map((cls) => cls.replace(/^hljs-/, ''))
+      stack.push(classes)
+    } else if (match[2] !== undefined) {
+      const text = decodeEntities(match[2])
+      if (text) {
+        segments.push({ text, ...resolveStyle(stack) })
+      }
+    } else {
+      stack.pop()
+    }
+  }
+
+  return segments
+}
+
+// Highlight a block of code and return an array of lines, where each line is an
+// array of styled runs. When no language is known, the code is returned as a
+// single uncoloured run per line.
+function highlightCode(code, lang) {
+  let html = null
+  if (lang && lang !== 'plaintext' && hljs.getLanguage(lang)) {
+    try {
+      html = hljs.highlight(code, { language: lang }).value
+    } catch (err) {
+      html = null
+    }
+  }
+
+  if (html === null) {
+    return code.split('\n').map((line) => (line ? [{ text: line, color: null, bold: false, italic: false }] : []))
+  }
+
+  const segments = htmlToSegments(html)
+  const lines = [[]]
+  for (const segment of segments) {
+    const parts = segment.text.split('\n')
+    for (let i = 0; i < parts.length; i++) {
+      if (i > 0) {
+        lines.push([])
+      }
+      if (parts[i].length > 0) {
+        lines[lines.length - 1].push({ text: parts[i], color: segment.color, bold: segment.bold, italic: segment.italic })
+      }
+    }
+  }
+
+  return lines
+}
+
+module.exports = { highlightCode, htmlToSegments }

--- a/src/pdf/layout.js
+++ b/src/pdf/layout.js
@@ -1,0 +1,583 @@
+const PDFDocument = require('./document')
+const { FONT_KEYS, measureText, encodePdfString } = require('./fonts')
+const { highlightCode } = require('./highlighter')
+const { parseBlocks } = require('./markdown')
+
+// Layout constants (in PDF points). Sizes are chosen to mirror the GitHub
+// markdown styling used by the HTML renderer while keeping pages dense and
+// readable.
+const PAGE = { width: 612, height: 792 }
+const MARGIN = { top: 54, bottom: 54, left: 54, right: 54 }
+const CONTENT_WIDTH = PAGE.width - MARGIN.left - MARGIN.right
+
+const BODY_SIZE = 11
+const BODY_LINE = 16
+const CODE_SIZE = 8.5
+const CODE_LINE = 11.5
+const CODE_PAD = 8
+const TABLE_SIZE = 9.5
+const TABLE_LINE = 13
+
+const HEADING = {
+  1: { size: 21, gapBefore: 16, gapAfter: 8, rule: true },
+  2: { size: 17, gapBefore: 14, gapAfter: 7, rule: true },
+  3: { size: 14.5, gapBefore: 12, gapAfter: 6, rule: false },
+  4: { size: 12.5, gapBefore: 12, gapAfter: 5, rule: false },
+  5: { size: 11.5, gapBefore: 10, gapAfter: 4, rule: false },
+  6: { size: 11, gapBefore: 10, gapAfter: 4, rule: false },
+}
+
+const COLORS = {
+  text: '#24292e',
+  heading: '#1f2328',
+  link: '#0366d6',
+  codeText: '#24292e',
+  codeBg: '#f6f8fa',
+  inlineCodeBg: '#eff1f3',
+  quoteText: '#6a737d',
+  quoteBar: '#dfe2e5',
+  rule: '#d8dee4',
+  border: '#d0d7de',
+  altRow: '#f6f8fa',
+  bullet: '#24292e',
+}
+
+const ASCENT = 0.78
+
+function hexToRgb(hex) {
+  const value = hex.replace('#', '')
+  const r = parseInt(value.slice(0, 2), 16) / 255
+  const g = parseInt(value.slice(2, 4), 16) / 255
+  const b = parseInt(value.slice(4, 6), 16) / 255
+  return `${round(r)} ${round(g)} ${round(b)}`
+}
+
+function round(n) {
+  return Math.round(n * 1000) / 1000
+}
+
+function runFont(run) {
+  if (run.code) {
+    return run.bold ? 'monoBold' : 'mono'
+  }
+  if (run.bold && run.italic) {
+    return 'bodyBoldItalic'
+  }
+  if (run.bold) {
+    return 'bodyBold'
+  }
+  if (run.italic) {
+    return 'bodyItalic'
+  }
+  return 'body'
+}
+
+function runColor(run, defaultColor) {
+  if (run.link) {
+    return COLORS.link
+  }
+  return defaultColor
+}
+
+class Layout {
+  constructor() {
+    this.doc = new PDFDocument(PAGE)
+    this.ops = []
+    this.y = MARGIN.top
+    this.pageIndex = 0
+    this.outline = []
+    this.headingStack = [] // for nested outline building
+    this.leftBar = null
+  }
+
+  // --- low level drawing --------------------------------------------------
+
+  _fillRect(x, top, w, h, color) {
+    const pdfY = round(PAGE.height - top - h)
+    this.ops.push(`${hexToRgb(color)} rg\n${round(x)} ${pdfY} ${round(w)} ${round(h)} re\nf`)
+  }
+
+  _strokeRect(x, top, w, h, color, lineWidth = 0.5) {
+    const pdfY = round(PAGE.height - top - h)
+    this.ops.push(`${lineWidth} w\n${hexToRgb(color)} RG\n${round(x)} ${pdfY} ${round(w)} ${round(h)} re\nS`)
+  }
+
+  _line(x1, top1, x2, top2, color, lineWidth = 0.5) {
+    this.ops.push(`${lineWidth} w\n${hexToRgb(color)} RG\n${round(x1)} ${round(PAGE.height - top1)} m ${round(x2)} ${round(PAGE.height - top2)} l S`)
+  }
+
+  // Draw a piece of text whose baseline sits `baselineTop` points below the top
+  // of the page.
+  _text(x, baselineTop, text, fontKey, size, color) {
+    if (!text) {
+      return
+    }
+    const pdfY = round(PAGE.height - baselineTop)
+    const encoded = encodePdfString(text).toString('latin1')
+    this.ops.push(`BT /${FONT_KEYS[fontKey]} ${size} Tf ${hexToRgb(color)} rg 1 0 0 1 ${round(x)} ${pdfY} Tm (${encoded}) Tj ET`)
+  }
+
+  // --- pagination ---------------------------------------------------------
+
+  _newPage() {
+    this.doc.addPage(this.ops.join('\n'))
+    this.ops = []
+    this.y = MARGIN.top
+    this.pageIndex += 1
+  }
+
+  _ensure(height) {
+    if (this.y + height > PAGE.height - MARGIN.bottom) {
+      this._newPage()
+      return true
+    }
+    return false
+  }
+
+  _drawLeftBar(top, height) {
+    if (this.leftBar) {
+      this._fillRect(this.leftBar.x, top, 3, height, this.leftBar.color)
+    }
+  }
+
+  // --- inline wrapping ----------------------------------------------------
+
+  // Break styled runs into lines that fit within `maxWidth`, keeping per-token
+  // styling. Returns an array of lines; each line is an array of
+  // { text, fontKey, color, code, width }.
+  _wrapInline(runs, maxWidth, size, defaultColor) {
+    const tokens = []
+    for (const run of runs) {
+      const fontKey = runFont(run)
+      const color = runColor(run, defaultColor)
+      const pieces = run.text.replace(/\t/g, '  ').split(/(\s+)/)
+      for (const piece of pieces) {
+        if (piece.length === 0) {
+          continue
+        }
+        tokens.push({ text: piece, fontKey, color, code: !!run.code, isSpace: /^\s+$/.test(piece) })
+      }
+    }
+
+    const lines = []
+    let line = []
+    let lineWidth = 0
+
+    const pushLine = () => {
+      while (line.length > 0 && line[line.length - 1].isSpace) {
+        line.pop()
+      }
+      lines.push(line)
+      line = []
+      lineWidth = 0
+    }
+
+    for (const token of tokens) {
+      let width = measureText(token.text, token.fontKey, size)
+
+      if (token.isSpace) {
+        if (line.length === 0) {
+          continue
+        }
+        line.push({ ...token, width })
+        lineWidth += width
+        continue
+      }
+
+      // Hard-break tokens that are wider than a full line.
+      if (width > maxWidth && line.length === 0) {
+        let remaining = token.text
+        while (measureText(remaining, token.fontKey, size) > maxWidth && remaining.length > 1) {
+          let fit = remaining.length
+          while (fit > 1 && measureText(remaining.slice(0, fit), token.fontKey, size) > maxWidth) {
+            fit--
+          }
+          lines.push([{ ...token, text: remaining.slice(0, fit), width: measureText(remaining.slice(0, fit), token.fontKey, size) }])
+          remaining = remaining.slice(fit)
+        }
+        width = measureText(remaining, token.fontKey, size)
+        line.push({ ...token, text: remaining, width })
+        lineWidth += width
+        continue
+      }
+
+      if (lineWidth + width > maxWidth && line.length > 0) {
+        pushLine()
+      }
+      line.push({ ...token, width })
+      lineWidth += width
+    }
+
+    pushLine()
+    return lines.length > 0 ? lines : [[]]
+  }
+
+  _emitInline(runs, x, maxWidth, size, lineHeight, defaultColor) {
+    const lines = this._wrapInline(runs, maxWidth, size, defaultColor)
+    for (const line of lines) {
+      this._ensure(lineHeight)
+      this._drawLeftBar(this.y, lineHeight)
+      const baseline = this.y + size * ASCENT
+      let cursor = x
+      for (const token of line) {
+        if (token.code && !token.isSpace) {
+          this._fillRect(cursor - 1, this.y + 1, token.width + 2, lineHeight - 2, COLORS.inlineCodeBg)
+        }
+        this._text(cursor, baseline, token.text, token.fontKey, size, token.code ? COLORS.codeText : token.color)
+        cursor += token.width
+      }
+      this.y += lineHeight
+    }
+  }
+
+  // --- block rendering ----------------------------------------------------
+
+  render(markdown) {
+    const blocks = parseBlocks(markdown)
+    this._renderBlocks(blocks, MARGIN.left, CONTENT_WIDTH)
+  }
+
+  _renderBlocks(blocks, left, width) {
+    let inToc = false
+
+    for (let i = 0; i < blocks.length; i++) {
+      const block = blocks[i]
+
+      switch (block.type) {
+        case 'heading': {
+          // Detect repo-to-pdf navigation/TOC artefacts.
+          const isContents = block.level === 2 && /^contents$/i.test(block.text)
+          const next = blocks[i + 1]
+          const isFileHeader = block.level === 4 && next && next.type === 'paragraph' && isToTopLink(next)
+
+          if (isContents) {
+            this._heading(block, left, width, { outline: false })
+            inToc = true
+            break
+          }
+
+          if (inToc && block.level === 4 && !isFileHeader) {
+            this._tocEntry(block, left, width)
+            break
+          }
+
+          inToc = false
+          this._heading(block, left, width, { outline: true })
+          break
+        }
+        case 'paragraph':
+          if (isToTopLink(block)) {
+            break // skip "[to top]" navigation links
+          }
+          inToc = false
+          this._emitInline(block.inlines, left, width, BODY_SIZE, BODY_LINE, COLORS.text)
+          this.y += 4
+          break
+        case 'code':
+          inToc = false
+          this._codeBlock(block, left, width)
+          break
+        case 'hr':
+          this._ensure(12)
+          this.y += 5
+          this._line(left, this.y, left + width, this.y, COLORS.rule, 1)
+          this.y += 7
+          break
+        case 'blockquote':
+          this._blockquote(block, left, width)
+          break
+        case 'list':
+          this._list(block, left, width)
+          break
+        case 'table':
+          this._table(block, left, width)
+          break
+        default:
+          break
+      }
+    }
+  }
+
+  _heading(block, left, width, { outline }) {
+    const spec = HEADING[block.level] || HEADING[6]
+    this.y += this.y > MARGIN.top ? spec.gapBefore : 0
+    this._ensure(spec.size + spec.gapAfter + (spec.rule ? 6 : 0))
+
+    if (outline && block.text) {
+      this._addOutline(block.level, block.text)
+    }
+
+    const runs = block.inlines.map((run) => ({ ...run, bold: true }))
+    this._emitInline(runs, left, width, spec.size, spec.size * 1.3, COLORS.heading)
+
+    if (spec.rule) {
+      this.y += 3
+      this._line(left, this.y, left + width, this.y, COLORS.rule, 0.75)
+      this.y += 1
+    }
+    this.y += spec.gapAfter
+  }
+
+  _tocEntry(block, left, width) {
+    // Render TOC index entries compactly without polluting the outline.
+    const runs = block.inlines.map((run) => ({ ...run, bold: false }))
+    this._emitInline(runs, left, width, 9.5, 13, COLORS.link)
+  }
+
+  _codeBlock(block, left, width) {
+    const lines = highlightCode(block.code, block.lang)
+    const innerWidth = width - 2 * CODE_PAD
+    const monoCharWidth = measureText('0', 'mono', CODE_SIZE)
+    const maxChars = Math.max(1, Math.floor(innerWidth / monoCharWidth))
+
+    const display = []
+    for (const lineRuns of lines) {
+      const wrapped = wrapMonoLine(lineRuns, maxChars)
+      for (const w of wrapped) {
+        display.push(w)
+      }
+    }
+
+    this.y += 4
+    let segStart = this.ops.length
+    let segTop = this.y
+    this.y += CODE_PAD
+
+    const finishSegment = () => {
+      const bottom = this.y + CODE_PAD
+      const rect = this._rectString(left, segTop, width, bottom - segTop, COLORS.codeBg)
+      this.ops.splice(segStart, 0, rect)
+      this.y = bottom
+    }
+
+    for (const lineRuns of display) {
+      if (this.y + CODE_LINE > PAGE.height - MARGIN.bottom) {
+        finishSegment()
+        this._newPage()
+        segStart = this.ops.length
+        segTop = this.y
+        this.y += CODE_PAD
+      }
+
+      const baseline = this.y + CODE_SIZE * ASCENT
+      let cursor = left + CODE_PAD
+      for (const run of lineRuns) {
+        const fontKey = run.bold ? 'monoBold' : 'mono'
+        this._text(cursor, baseline, run.text, fontKey, CODE_SIZE, run.color || COLORS.codeText)
+        cursor += measureText(run.text, fontKey, CODE_SIZE)
+      }
+      this.y += CODE_LINE
+    }
+
+    finishSegment()
+    this.y += 6
+  }
+
+  // Build a fill-rectangle op string without appending it (used for splicing
+  // backgrounds beneath already-emitted text).
+  _rectString(x, top, w, h, color) {
+    const pdfY = round(PAGE.height - top - h)
+    return `${hexToRgb(color)} rg\n${round(x)} ${pdfY} ${round(w)} ${round(h)} re\nf`
+  }
+
+  _blockquote(block, left, width) {
+    const previousBar = this.leftBar
+    this.y += 4
+    this.leftBar = { x: left, color: COLORS.quoteBar }
+    const indent = 14
+    const quoteColor = COLORS.quoteText
+    this._renderQuoteBlocks(block.blocks, left + indent, width - indent, quoteColor)
+    this.leftBar = previousBar
+    this.y += 4
+  }
+
+  _renderQuoteBlocks(blocks, left, width, color) {
+    for (const block of blocks) {
+      if (block.type === 'paragraph') {
+        this._emitInline(block.inlines, left, width, BODY_SIZE, BODY_LINE, color)
+        this.y += 2
+      } else if (block.type === 'heading') {
+        this._emitInline(
+          block.inlines.map((r) => ({ ...r, bold: true })),
+          left,
+          width,
+          (HEADING[block.level] || HEADING[6]).size,
+          (HEADING[block.level] || HEADING[6]).size * 1.3,
+          color
+        )
+        this.y += 2
+      } else if (block.type === 'code') {
+        this._codeBlock(block, left, width)
+      } else if (block.type === 'list') {
+        this._list(block, left, width, color)
+      }
+    }
+  }
+
+  _list(block, left, width, color = COLORS.text) {
+    let index = 1
+    for (const item of block.items) {
+      const marker = block.ordered ? `${index}.` : '\u2022'
+      const markerWidth = 18
+      this._ensure(BODY_LINE)
+      const baseline = this.y + BODY_SIZE * ASCENT
+      this._drawLeftBar(this.y, BODY_LINE)
+      this._text(left + 2, baseline, marker, 'body', BODY_SIZE, color)
+
+      const startY = this.y
+      this._emitInline(item.inlines, left + markerWidth, width - markerWidth, BODY_SIZE, BODY_LINE, color)
+      if (this.y === startY) {
+        this.y += BODY_LINE
+      }
+
+      if (item.blocks && item.blocks.length) {
+        this._renderBlocks(item.blocks, left + markerWidth, width - markerWidth)
+      }
+      index++
+    }
+    this.y += 4
+  }
+
+  _table(block, left, width) {
+    const colCount = Math.max(block.header.length, ...block.rows.map((r) => r.length), 1)
+    const padX = 5
+    const padY = 3
+
+    // Natural widths from single-line cell measurements, then scaled to fit.
+    const natural = new Array(colCount).fill(20)
+    const allRows = [block.header, ...block.rows]
+    for (const row of allRows) {
+      for (let c = 0; c < colCount; c++) {
+        const cell = row[c] || []
+        const text = cell.map((r) => r.text).join('')
+        natural[c] = Math.max(natural[c], measureText(text, 'body', TABLE_SIZE) + 2 * padX)
+      }
+    }
+    const naturalSum = natural.reduce((a, b) => a + b, 0)
+    const scale = width / naturalSum
+    const colWidths = natural.map((w) => w * scale)
+
+    const drawRow = (cells, isHeader, rowIndex) => {
+      const cellLines = []
+      let maxLines = 1
+      for (let c = 0; c < colCount; c++) {
+        const runs = (cells[c] || []).map((r) => (isHeader ? { ...r, bold: true } : r))
+        const lines = this._wrapInline(runs, colWidths[c] - 2 * padX, TABLE_SIZE, COLORS.text)
+        cellLines.push(lines)
+        maxLines = Math.max(maxLines, lines.length)
+      }
+      const rowHeight = maxLines * TABLE_LINE + 2 * padY
+
+      if (this.y + rowHeight > PAGE.height - MARGIN.bottom && this.y > MARGIN.top) {
+        this._newPage()
+      }
+
+      const rowTop = this.y
+      if (!isHeader && rowIndex % 2 === 1) {
+        this._fillRect(left, rowTop, width, rowHeight, COLORS.altRow)
+      }
+
+      let x = left
+      for (let c = 0; c < colCount; c++) {
+        const lines = cellLines[c]
+        let textTop = rowTop + padY
+        for (const line of lines) {
+          const baseline = textTop + TABLE_SIZE * ASCENT
+          let cursor = x + padX
+          for (const token of line) {
+            this._text(cursor, baseline, token.text, token.fontKey, TABLE_SIZE, token.color)
+            cursor += token.width
+          }
+          textTop += TABLE_LINE
+        }
+        this._strokeRect(x, rowTop, colWidths[c], rowHeight, COLORS.border, 0.5)
+        x += colWidths[c]
+      }
+      this.y = rowTop + rowHeight
+    }
+
+    this.y += 4
+    drawRow(block.header, true, -1)
+    block.rows.forEach((row, idx) => drawRow(row, false, idx))
+    this.y += 6
+  }
+
+  // --- outline ------------------------------------------------------------
+
+  _addOutline(level, title) {
+    const node = { title, level, pageIndex: this.pageIndex, y: PAGE.height - this.y + 2, children: [] }
+
+    while (this.headingStack.length > 0 && this.headingStack[this.headingStack.length - 1].level >= level) {
+      this.headingStack.pop()
+    }
+
+    if (this.headingStack.length === 0) {
+      this.outline.push(node)
+    } else {
+      this.headingStack[this.headingStack.length - 1].children.push(node)
+    }
+    this.headingStack.push(node)
+  }
+
+  finish(options = {}) {
+    if (this.ops.length > 0 || this.doc.pages.length === 0) {
+      this.doc.addPage(this.ops.join('\n'))
+      this.ops = []
+    }
+    const outline = options.outline === false ? null : this.outline
+    return this.doc.build(outline)
+  }
+}
+
+// Wrap a single source line (array of styled runs) to at most `maxChars`
+// monospace characters per display line.
+function wrapMonoLine(runs, maxChars) {
+  if (!runs || runs.length === 0) {
+    return [[]]
+  }
+
+  const out = []
+  let current = []
+  let length = 0
+
+  for (const run of runs) {
+    const text = run.text.replace(/\t/g, '  ')
+    let index = 0
+    while (index < text.length) {
+      const space = maxChars - length
+      if (space <= 0) {
+        out.push(current)
+        current = []
+        length = 0
+        continue
+      }
+      const take = text.slice(index, index + space)
+      current.push({ text: take, color: run.color, bold: run.bold, italic: run.italic })
+      length += take.length
+      index += take.length
+    }
+  }
+  out.push(current)
+  return out
+}
+
+function isToTopLink(paragraph) {
+  if (!paragraph || paragraph.type !== 'paragraph') {
+    return false
+  }
+  const runs = paragraph.inlines
+  if (runs.length !== 1) {
+    return false
+  }
+  const run = runs[0]
+  return run.link && /^#contents$/i.test(run.link) && /to top/i.test(run.text)
+}
+
+// Render a markdown string into a PDF Buffer.
+function renderMarkdownToPdf(markdown, options = {}) {
+  const layout = new Layout()
+  layout.render(markdown)
+  return layout.finish(options)
+}
+
+module.exports = { renderMarkdownToPdf, Layout }

--- a/src/pdf/markdown.js
+++ b/src/pdf/markdown.js
@@ -1,0 +1,383 @@
+// A small, dependency-free Markdown parser. It only implements the subset of
+// CommonMark/GFM that repo-to-pdf emits (headings, paragraphs, fenced code,
+// lists, blockquotes, tables, rules) plus the common inline constructs. The
+// goal is readable output, not perfect spec compliance.
+
+const ENTITIES = {
+  '&amp;': '&',
+  '&lt;': '<',
+  '&gt;': '>',
+  '&quot;': '"',
+  '&#x27;': "'",
+  '&#39;': "'",
+  '&#x2F;': '/',
+  '&nbsp;': ' ',
+  '&copy;': '\u00a9',
+  '&reg;': '\u00ae',
+  '&mdash;': '\u2014',
+  '&ndash;': '\u2013',
+  '&hellip;': '\u2026',
+}
+
+function decodeEntities(text) {
+  return text
+    .replace(/&(?:amp|lt|gt|quot|nbsp|copy|reg|mdash|ndash|hellip|#x27|#39|#x2F);/g, (match) => ENTITIES[match] || match)
+    .replace(/&#x([0-9a-fA-F]+);/g, (_m, code) => safeCodePoint(parseInt(code, 16)))
+    .replace(/&#(\d+);/g, (_m, code) => safeCodePoint(Number(code)))
+}
+
+function safeCodePoint(code) {
+  try {
+    return String.fromCodePoint(code)
+  } catch (err) {
+    return ''
+  }
+}
+
+const HEADING_RE = /^(#{1,6})\s+(.*?)\s*#*\s*$/
+const FENCE_RE = /^(\s*)(`{3,}|~{3,})\s*([^`]*)$/
+const HR_RE = /^\s*([-*_])(?:\s*\1){2,}\s*$/
+const LIST_RE = /^(\s*)([-*+]|\d+[.)])\s+(.*)$/
+const BLOCKQUOTE_RE = /^\s*>\s?(.*)$/
+const TABLE_SEP_RE = /^\s*\|?\s*:?-{1,}:?\s*(\|\s*:?-{1,}:?\s*)*\|?\s*$/
+
+function isBlank(line) {
+  return /^\s*$/.test(line)
+}
+
+// Split a GFM table row into trimmed cell strings.
+function splitTableRow(line) {
+  let trimmed = line.trim()
+  if (trimmed.startsWith('|')) {
+    trimmed = trimmed.slice(1)
+  }
+  if (trimmed.endsWith('|')) {
+    trimmed = trimmed.slice(0, -1)
+  }
+
+  const cells = []
+  let current = ''
+  for (let i = 0; i < trimmed.length; i++) {
+    const ch = trimmed[i]
+    if (ch === '\\' && trimmed[i + 1] === '|') {
+      current += '|'
+      i++
+    } else if (ch === '|') {
+      cells.push(current.trim())
+      current = ''
+    } else {
+      current += ch
+    }
+  }
+  cells.push(current.trim())
+  return cells
+}
+
+function parseBlocks(markdown) {
+  const lines = markdown.replace(/\r\n?/g, '\n').split('\n')
+  const blocks = []
+  let i = 0
+
+  while (i < lines.length) {
+    const line = lines[i]
+
+    if (isBlank(line)) {
+      i++
+      continue
+    }
+
+    const fence = line.match(FENCE_RE)
+    if (fence) {
+      const marker = fence[2][0]
+      const lang = fence[3].trim().split(/\s+/)[0].toLowerCase()
+      const code = []
+      i++
+      while (i < lines.length && !new RegExp(`^\\s*${marker}{3,}\\s*$`).test(lines[i])) {
+        code.push(lines[i])
+        i++
+      }
+      i++ // skip closing fence
+      blocks.push({ type: 'code', lang, code: code.join('\n') })
+      continue
+    }
+
+    const heading = line.match(HEADING_RE)
+    if (heading) {
+      blocks.push({ type: 'heading', level: heading[1].length, inlines: parseInline(heading[2]), text: stripInline(heading[2]) })
+      i++
+      continue
+    }
+
+    if (HR_RE.test(line)) {
+      blocks.push({ type: 'hr' })
+      i++
+      continue
+    }
+
+    if (BLOCKQUOTE_RE.test(line)) {
+      const quoteLines = []
+      while (i < lines.length && BLOCKQUOTE_RE.test(lines[i])) {
+        quoteLines.push(lines[i].match(BLOCKQUOTE_RE)[1])
+        i++
+      }
+      blocks.push({ type: 'blockquote', blocks: parseBlocks(quoteLines.join('\n')) })
+      continue
+    }
+
+    // GFM table: header row followed by a delimiter row.
+    if (line.includes('|') && i + 1 < lines.length && TABLE_SEP_RE.test(lines[i + 1]) && lines[i + 1].includes('-')) {
+      const header = splitTableRow(line).map((cell) => parseInline(cell))
+      i += 2
+      const rows = []
+      while (i < lines.length && !isBlank(lines[i]) && lines[i].includes('|')) {
+        rows.push(splitTableRow(lines[i]).map((cell) => parseInline(cell)))
+        i++
+      }
+      blocks.push({ type: 'table', header, rows })
+      continue
+    }
+
+    if (LIST_RE.test(line)) {
+      const { list, next } = parseList(lines, i)
+      blocks.push(list)
+      i = next
+      continue
+    }
+
+    // Paragraph: gather consecutive lines until a blank line or new block start.
+    const para = []
+    while (i < lines.length && !isBlank(lines[i])) {
+      const current = lines[i]
+      if (HEADING_RE.test(current) || FENCE_RE.test(current) || HR_RE.test(current) || BLOCKQUOTE_RE.test(current) || LIST_RE.test(current)) {
+        break
+      }
+      para.push(current.trim())
+      i++
+    }
+    if (para.length > 0) {
+      blocks.push({ type: 'paragraph', inlines: parseInline(para.join('\n')) })
+    }
+  }
+
+  return blocks
+}
+
+// Parse a (possibly nested) list starting at index `start`.
+function parseList(lines, start) {
+  const first = lines[start].match(LIST_RE)
+  const baseIndent = first[1].length
+  const ordered = /\d/.test(first[2])
+  const items = []
+  let i = start
+
+  while (i < lines.length) {
+    const match = lines[i].match(LIST_RE)
+    if (!match || match[1].length < baseIndent) {
+      break
+    }
+
+    if (match[1].length > baseIndent) {
+      // Nested list belongs to the previous item.
+      const { list, next } = parseList(lines, i)
+      if (items.length > 0) {
+        items[items.length - 1].blocks.push(list)
+      }
+      i = next
+      continue
+    }
+
+    const itemLines = [match[3]]
+    i++
+    // Continuation lines (indented or plain) until a blank line or next item.
+    while (i < lines.length && !isBlank(lines[i]) && !LIST_RE.test(lines[i])) {
+      itemLines.push(lines[i].trim())
+      i++
+    }
+    items.push({ inlines: parseInline(itemLines.join(' ')), blocks: [], ordered })
+
+    while (i < lines.length && isBlank(lines[i])) {
+      // Allow one blank line between items without ending the list.
+      if (i + 1 < lines.length && LIST_RE.test(lines[i + 1]) && lines[i + 1].match(LIST_RE)[1].length >= baseIndent) {
+        i++
+      } else {
+        break
+      }
+    }
+  }
+
+  return { list: { type: 'list', ordered, items }, next: i }
+}
+
+// --- Inline parsing -------------------------------------------------------
+
+// Convert inline markdown text into an array of styled runs:
+// { text, bold, italic, code, link }
+function parseInline(text) {
+  const runs = []
+  scanInline(text, { bold: false, italic: false, code: false, link: null }, runs)
+  return mergeRuns(runs)
+}
+
+function pushRun(runs, text, style) {
+  if (text.length === 0) {
+    return
+  }
+  runs.push({ text, bold: style.bold, italic: style.italic, code: style.code, link: style.link })
+}
+
+function scanInline(text, style, runs) {
+  let buffer = ''
+  let i = 0
+
+  const flush = () => {
+    if (buffer) {
+      pushRun(runs, decodeEntities(buffer), style)
+      buffer = ''
+    }
+  }
+
+  while (i < text.length) {
+    const ch = text[i]
+    const rest = text.slice(i)
+
+    // Escaped character.
+    if (ch === '\\' && i + 1 < text.length) {
+      buffer += text[i + 1]
+      i += 2
+      continue
+    }
+
+    // Inline code span.
+    if (ch === '`') {
+      const fenceMatch = rest.match(/^(`+)/)
+      const ticks = fenceMatch[1]
+      const closeIndex = text.indexOf(ticks, i + ticks.length)
+      if (closeIndex !== -1) {
+        flush()
+        const codeText = text.slice(i + ticks.length, closeIndex).replace(/^ | $/g, '')
+        pushRun(runs, codeText, { ...style, code: true })
+        i = closeIndex + ticks.length
+        continue
+      }
+    }
+
+    // Image: render the alt text only (images are not embedded).
+    if (ch === '!' && text[i + 1] === '[') {
+      const image = matchLink(rest.slice(1))
+      if (image) {
+        flush()
+        if (image.text) {
+          scanInline(image.text, style, runs)
+        }
+        i += 1 + image.length
+        continue
+      }
+    }
+
+    // Link.
+    if (ch === '[') {
+      const link = matchLink(rest)
+      if (link) {
+        flush()
+        scanInline(link.text, { ...style, link: link.url }, runs)
+        i += link.length
+        continue
+      }
+    }
+
+    // Strong emphasis.
+    if (rest.startsWith('**') || rest.startsWith('__')) {
+      const marker = rest.slice(0, 2)
+      const end = text.indexOf(marker, i + 2)
+      if (end !== -1 && end > i + 2) {
+        flush()
+        scanInline(text.slice(i + 2, end), { ...style, bold: true }, runs)
+        i = end + 2
+        continue
+      }
+    }
+
+    // Emphasis.
+    if ((ch === '*' || ch === '_') && text[i + 1] !== ch) {
+      const end = text.indexOf(ch, i + 1)
+      if (end !== -1 && end > i + 1) {
+        flush()
+        scanInline(text.slice(i + 1, end), { ...style, italic: true }, runs)
+        i = end + 1
+        continue
+      }
+    }
+
+    // Strip inline HTML tags.
+    if (ch === '<') {
+      const close = text.indexOf('>', i)
+      if (close !== -1 && /^<\/?[a-zA-Z!][^>]*>$/.test(text.slice(i, close + 1))) {
+        i = close + 1
+        continue
+      }
+    }
+
+    buffer += ch
+    i++
+  }
+
+  flush()
+}
+
+// Match a [text](url) construct at the start of `str`. Returns the link text,
+// url and total consumed length, or null.
+function matchLink(str) {
+  if (str[0] !== '[') {
+    return null
+  }
+  let depth = 0
+  let i = 0
+  for (; i < str.length; i++) {
+    if (str[i] === '\\') {
+      i++
+      continue
+    }
+    if (str[i] === '[') {
+      depth++
+    } else if (str[i] === ']') {
+      depth--
+      if (depth === 0) {
+        break
+      }
+    }
+  }
+  if (depth !== 0 || str[i + 1] !== '(') {
+    return null
+  }
+  const text = str.slice(1, i)
+  const close = str.indexOf(')', i + 2)
+  if (close === -1) {
+    return null
+  }
+  const url = str.slice(i + 2, close).split(/\s+/)[0]
+  return { text, url, length: close + 1 }
+}
+
+// Combine adjacent runs that share identical styling.
+function mergeRuns(runs) {
+  const merged = []
+  for (const run of runs) {
+    const last = merged[merged.length - 1]
+    if (last && last.bold === run.bold && last.italic === run.italic && last.code === run.code && last.link === run.link) {
+      last.text += run.text
+    } else {
+      merged.push({ ...run })
+    }
+  }
+  return merged
+}
+
+// Plain-text version of inline markdown, used for outline/bookmark titles.
+function stripInline(text) {
+  return parseInline(text)
+    .map((run) => run.text)
+    .join('')
+    .trim()
+}
+
+module.exports = { parseBlocks, parseInline, stripInline }

--- a/test/native.test.js
+++ b/test/native.test.js
@@ -1,0 +1,127 @@
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+
+const { generateEbook } = require('../src/html')
+const { getSizeInByte } = require('../src/utils')
+const { isPdf } = require('./utils/write-mock-pdf')
+const { getPdfOutlineCount } = require('./utils/pdf-outline')
+const { parseBlocks, parseInline } = require('../src/pdf/markdown')
+const { highlightCode } = require('../src/pdf/highlighter')
+const { renderMarkdownToPdf } = require('../src/pdf/layout')
+
+jest.setTimeout(60 * 1000)
+
+const baseUrl = path.resolve(__dirname, '../html5bp')
+const PDF_SIZE = getSizeInByte(5)
+
+function nativeOptions(overrides = {}) {
+  return {
+    renderer: 'native',
+    pdf_size: PDF_SIZE,
+    white_list: null,
+    format: 'pdf',
+    device: 'desktop',
+    baseUrl,
+    ...overrides,
+  }
+}
+
+describe('native PDF renderer', () => {
+  const created = []
+
+  afterAll(() => {
+    created.forEach((file) => fs.existsSync(file) && fs.rmSync(file, { force: true }))
+  })
+
+  it('generates a valid PDF without external dependencies', async () => {
+    const output = 'native-self.pdf'
+    created.push(output)
+    await generateEbook('./src', output, 'repo-to-pdf', nativeOptions())
+    expect(isPdf(output)).toBe(true)
+    expect(fs.statSync(output).size).toBeGreaterThan(0)
+  })
+
+  it('embeds a PDF outline when enabled', async () => {
+    const output = 'native-outline.pdf'
+    created.push(output)
+    await generateEbook('./src', output, 'repo-to-pdf', nativeOptions({ outline: true }))
+    expect(getPdfOutlineCount(output)).toBeGreaterThan(0)
+  })
+
+  it('omits the PDF outline when disabled', async () => {
+    const output = 'native-no-outline.pdf'
+    created.push(output)
+    await generateEbook('./src', output, 'repo-to-pdf', nativeOptions({ outline: false }))
+    expect(getPdfOutlineCount(output)).toBe(0)
+  })
+
+  it('renders diverse example sources (markdown, tables, unicode, long lines)', async () => {
+    const output = 'native-examples.pdf'
+    created.push(output)
+    await generateEbook(path.join(__dirname, 'examples'), output, 'examples', nativeOptions())
+    expect(isPdf(output)).toBe(true)
+  })
+
+  it('splits into multiple PDFs when the size limit is exceeded', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'repo-to-pdf-native-'))
+    const longSource = Array.from({ length: 400 }, (_, i) => `const value${i} = ${i} // line ${i}`).join('\n')
+    fs.writeFileSync(path.join(tmpDir, 'a.js'), longSource)
+    fs.writeFileSync(path.join(tmpDir, 'b.js'), longSource)
+
+    const output = path.join(tmpDir, 'book.pdf')
+    await generateEbook(tmpDir, output, 'book', nativeOptions({ pdf_size: 4000 }))
+
+    expect(isPdf(path.join(tmpDir, 'book-1.pdf'))).toBe(true)
+    expect(isPdf(path.join(tmpDir, 'book-2.pdf'))).toBe(true)
+
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+})
+
+describe('markdown parser', () => {
+  it('parses headings, code fences and inline styles', () => {
+    const blocks = parseBlocks('# Title\n\nSome **bold** and `code`.\n\n```js\nconst x = 1\n```')
+    expect(blocks[0]).toMatchObject({ type: 'heading', level: 1, text: 'Title' })
+    expect(blocks[1].type).toBe('paragraph')
+    expect(blocks[2]).toMatchObject({ type: 'code', lang: 'js' })
+  })
+
+  it('parses links and emphasis into styled runs', () => {
+    const runs = parseInline('see [the docs](https://example.com) and *italics*')
+    const link = runs.find((r) => r.link)
+    const italic = runs.find((r) => r.italic)
+    expect(link).toBeTruthy()
+    expect(link.link).toBe('https://example.com')
+    expect(italic).toBeTruthy()
+  })
+
+  it('parses GFM tables', () => {
+    const blocks = parseBlocks('| A | B |\n| --- | --- |\n| 1 | 2 |')
+    expect(blocks[0].type).toBe('table')
+    expect(blocks[0].header).toHaveLength(2)
+    expect(blocks[0].rows).toHaveLength(1)
+  })
+})
+
+describe('syntax highlighter', () => {
+  it('produces coloured runs for known languages', () => {
+    const lines = highlightCode('const x = 1 // comment', 'javascript')
+    const flat = lines.flat()
+    expect(flat.some((run) => run.color)).toBe(true)
+    expect(flat.map((run) => run.text).join('')).toContain('const')
+  })
+
+  it('falls back to plain runs for unknown languages', () => {
+    const lines = highlightCode('hello world', 'not-a-language')
+    expect(lines.flat().every((run) => run.color === null)).toBe(true)
+  })
+})
+
+describe('layout', () => {
+  it('renders markdown to a PDF buffer with a %PDF header', () => {
+    const buffer = renderMarkdownToPdf('# Heading\n\nParagraph text.', { outline: true })
+    expect(buffer.slice(0, 5).toString('latin1')).toBe('%PDF-')
+    expect(buffer.toString('latin1').trimEnd().endsWith('%%EOF')).toBe(true)
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Motivation

Puppeteer (and the other browser/binary-based renderers) are slow and CPU-hungry: rendering the redis source took ~1m40s with the `node` renderer. This PR adds a **`native`** renderer — a highly efficient, dependency-free PDF generator that reads source code and writes PDF directly, with no headless browser or external runtime dependency.

## What it does

- **Reads source → writes PDF directly**, no intermediate HTML and no Chromium.
- **Imitates the HTML/GitHub styling** for readability: h1/h2 with bottom rules, sized headings, light-gray rounded code blocks, blockquotes, lists, GFM tables, inline code, links.
- **Syntax highlighting via `highlight.js`** (the only allowed dependency), mapped to the same Visual Studio palette used by `html5bp/css/vs.css`, so output matches the existing HTML pipeline.
- **PDF table of contents**: real, nested PDF bookmarks/outline built from file/heading structure (honors the existing `--no-outline` flag).
- **Tiny output**: only the built-in base-14 PDF fonts are referenced (never embedded) and every content stream is `FlateDecode`-compressed. The repo's own `src/` produces a ~91 KB / 43-page PDF in ~0.1s; `highlight.js/lib` (851 pages) renders in ~0.74s at ~1.4 MB (≈12× smaller per page than the puppeteer `sample.pdf`).

## Implementation

New `src/pdf/` module, all written from scratch with no new dependencies:

| file | responsibility |
| --- | --- |
| `document.js` | minimal PDF writer: objects, pages, base-14 fonts, flate compression, nested outline |
| `fonts.js` | standard font metrics + WinAnsi encoding (so fonts never need embedding) |
| `highlighter.js` | highlight.js HTML → styled coloured runs |
| `markdown.js` | small Markdown parser for the subset repo-to-pdf emits |
| `layout.js` | paginating layout engine + bookmark collection |
| `../native.js` | renders a RepoBook part to a PDF file |

The renderer is wired into `generateEbook` and exposed as `-r native`. **`node` (puppeteer) remains the default renderer**; `wkhtmltopdf` and `calibre` are unchanged and still available.

## Trade-off

Because output references the standard fonts rather than embedding any, glyphs outside WinAnsi (e.g. CJK) are substituted with a placeholder. Use `-r node` if full Unicode coverage is required. This is documented in the README.

## Testing

- `npm test` → 8 suites / 31 tests passing (existing 20 + 11 new).
- New `test/native.test.js` covers end-to-end PDF generation, outline on/off, multi-part splitting, the markdown parser, the highlighter, and the layout engine.
- `npm run format:check` passes.
- Verified visually by rendering generated PDFs to PNG (headings/rules, TOC links, multi-language highlighting, code wrapping, tables, large-document pagination).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4755e9ce-59fa-4307-939f-1c5ddc87412c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4755e9ce-59fa-4307-939f-1c5ddc87412c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

