### PR TITLE
Add exclude option with Unix glob pattern support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   - available via `-r native`
 - add `--footer-chapter-title` option to show chapter titles in the footer
 - add `--footer-page-number` option to show page numbers in the footer
+- add `-x, --exclude` option to exclude files by glob patterns
 
 ## v0.1.12(2026-06-16)
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ const { generateEbook } = require('repo-to-pdf')
  * @property {string} renderer - [native|node|calibre|wkhtmltopdf] node (puppeteer, default), native (built-in, dependency-free), calibre or wkhtmltopdf
  * @property {string} calibrePath - path of calibre's ebook-convert
  * @property {string} pdf_size - pdf size limit, in bytes
- * @property {string} white_list - list of file extensions to be included, separate by ','
+ * @property {string|string[]} white_list - list of file extensions to be included, separate by ','
+ * @property {string|string[]} exclude_list - list of file paths to exclude, using Unix glob patterns
  * @property {string} format - [mobi|epub|pdf] can be either mobi, epub, pdf
  * @property {string} device - [desktop|tablet|mobile] style can be opt for desktop, tablet and mobile
  * @property {string} baseUrl - base url of CSS style files
@@ -82,6 +83,10 @@ pdf filename
 -w, --whitelist [wlist]
 file format white list, split by ","
 # npx repo-to-pdf ../repo -w js,md
+
+-x, --exclude <patterns>
+file paths to exclude, using Unix glob patterns, split by ","
+# npx repo-to-pdf ../repo -x "**/*.test.js,src/generated/**"
 
 -s, --size [size]
 pdf file size limit, in MB, default 10 MB

--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -14,6 +14,7 @@ program
   .option('-d, --device <platform>', 'device [desktop(default)|mobile|tablet]', 'desktop')
   .option('-t, --title [name]', 'title')
   .option('-w, --whitelist [wlist]', 'file format white list, split by ,')
+  .option('-x, --exclude <patterns>', 'file paths to exclude, Unix glob patterns split by ,')
   .option('-s, --size [size]', 'pdf file size limit, in Mb')
   .option('-r, --renderer <engine>', '[native|node|wkhtmltopdf|calibre] native(built-in, no deps), node(puppeteer, default), wkhtmltopdf or calibre', 'node')
   .option('-f, --format <ext>', 'output format, pdf|mobi|epub', 'pdf')
@@ -36,6 +37,7 @@ const device = program.device
 const pdf_size = program.size ? getSizeInByte(program.size) : PDF_SIZE
 const format = program.format
 const white_list = program.whitelist
+const exclude_list = program.exclude
 const renderer = program.renderer
 const calibrePath = program.calibre
 const baseUrl = program.baseUrl
@@ -49,6 +51,7 @@ generateEbook(inputFolder, outputFile, title, {
   calibrePath,
   pdf_size,
   white_list,
+  exclude_list,
   format,
   device,
   baseUrl,

--- a/src/html.js
+++ b/src/html.js
@@ -186,7 +186,8 @@ function checkOptions(options) {
  * @property {string} renderer - [native|node|calibre|wkhtmltopdf] node (puppeteer, default), native (built-in, dependency-free), calibre or wkhtmltopdf
  * @property {string} calibrePath - path of calibre's ebook-convert
  * @property {string} pdf_size - pdf size limit, in bytes
- * @property {string} white_list - list of file extensions to be included, separate by ','
+ * @property {string|string[]} white_list - list of file extensions to be included, separate by ','
+ * @property {string|string[]} exclude_list - list of file paths to exclude, using Unix glob patterns
  * @property {string} format - [mobi|epub|pdf] can be either mobi, epub, pdf
  * @property {string} device - [desktop|tablet|mobile] style can be opt for desktop, tablet and mobile
  * @property {string} baseUrl - base url of CSS style files
@@ -208,8 +209,8 @@ async function generateEbook(inputFolder, outputFile, title, options = { rendere
     return
   }
 
-  const { pdf_size, white_list, renderer } = options
-  const repoBook = new RepoBook(inputFolder, title, pdf_size, white_list)
+  const { pdf_size, white_list, exclude_list, renderer } = options
+  const repoBook = new RepoBook(inputFolder, title, pdf_size, white_list, exclude_list)
 
   const defaultOutputFileName = getFileName(inputFolder) + '.pdf'
   const outputFileName = outputFile || defaultOutputFileName

--- a/src/repo.js
+++ b/src/repo.js
@@ -2,7 +2,7 @@ const path = require('path')
 const fs = require('fs')
 const hljs = require('highlight.js')
 const { pathToFileURL } = require('url')
-const { getFileName, getCleanFilename } = require('./utils')
+const { getFileName, getCleanFilename, parsePathList, isPathExcluded } = require('./utils')
 
 const MAX_FILE_SIZE_BYTES = 2 * 1000 * 1000
 
@@ -51,11 +51,12 @@ function resolveMarkdownImageReferences(markdown, markdownFile) {
 }
 
 class RepoBook {
-  constructor(dir, title, pdf_size, white_list) {
+  constructor(dir, title, pdf_size, white_list, exclude_list) {
     this.title = title
     this.pdf_size = pdf_size
 
     this.blackList = ['node_modules', 'vendor']
+    this.excludeList = parsePathList(exclude_list)
     this.whiteList = white_list
       ? white_list
           .split(',')
@@ -121,6 +122,10 @@ class RepoBook {
     })
   }
 
+  isExcluded(file) {
+    return isPathExcluded(file, this.dir, this.excludeList)
+  }
+
   getLanguageForFile(file) {
     const stat = fs.lstatSync(file)
     if (!stat.isFile() || stat.size > MAX_FILE_SIZE_BYTES) {
@@ -150,16 +155,17 @@ class RepoBook {
       const f = path.join(dir, name)
       const stat = fs.lstatSync(f)
       const blackListHit = this.blackList.filter((e) => !!f.match(e)).length > 0
+      const excluded = blackListHit || this.isExcluded(f)
 
       if (stat.isDirectory()) {
-        if (path.basename(f)[0] !== '.' && blackListHit === false) {
+        if (path.basename(f)[0] !== '.' && excluded === false) {
           const nestedEntries = this.readDir(f, [], level + 1)
           if (nestedEntries.length > 0) {
             entries.push([f, level + 1, true])
             entries.push(...nestedEntries)
           }
         }
-      } else if (this.getLanguageForFile(f)) {
+      } else if (!excluded && this.getLanguageForFile(f)) {
         entries.push([f, level + 1, false])
       }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,106 @@
 const path = require('path')
 
+function parsePathList(value) {
+  if (!value) {
+    return []
+  }
+
+  const entries = Array.isArray(value) ? value : String(value).split(',')
+  return entries.map((entry) => String(entry).trim()).filter(Boolean)
+}
+
+function globPatternToRegex(glob) {
+  let regex = ''
+  let i = 0
+
+  while (i < glob.length) {
+    const char = glob[i]
+
+    if (char === '*') {
+      if (glob[i + 1] === '*') {
+        regex += '.*'
+        i += 2
+        if (glob[i] === '/') {
+          i++
+        }
+      } else {
+        regex += '[^/]*'
+        i++
+      }
+      continue
+    }
+
+    if (char === '?') {
+      regex += '[^/]'
+      i++
+      continue
+    }
+
+    if (char === '[') {
+      const end = glob.indexOf(']', i)
+      if (end === -1) {
+        regex += '\\['
+        i++
+        continue
+      }
+
+      regex += glob.slice(i, end + 1)
+      i = end + 1
+      continue
+    }
+
+    if ('\\^$+.|(){}'.includes(char)) {
+      regex += '\\' + char
+    } else {
+      regex += char
+    }
+    i++
+  }
+
+  return regex
+}
+
+function globPatternToRegExp(glob) {
+  if (glob.endsWith('/**')) {
+    const prefix = glob.slice(0, -3)
+    return new RegExp('^' + globPatternToRegex(prefix) + '(/.*)?$')
+  }
+
+  return new RegExp('^' + globPatternToRegex(glob) + '$')
+}
+
+function matchesGlobPattern(target, pattern) {
+  return globPatternToRegExp(pattern).test(target)
+}
+
+function isPathExcluded(absolutePath, rootDir, patterns) {
+  if (patterns.length === 0) {
+    return false
+  }
+
+  const relativePath = path.relative(rootDir, absolutePath).split(path.sep).join('/')
+  const basename = path.basename(absolutePath)
+
+  return patterns.some((pattern) => {
+    if (matchesGlobPattern(relativePath, pattern) || matchesGlobPattern(basename, pattern)) {
+      return true
+    }
+
+    if (pattern.startsWith('**/')) {
+      const nestedPattern = pattern.slice(3)
+      if (matchesGlobPattern(relativePath, nestedPattern) || matchesGlobPattern(basename, nestedPattern)) {
+        return true
+      }
+    }
+
+    if (!pattern.includes('/')) {
+      return relativePath.split('/').some((segment) => matchesGlobPattern(segment, pattern))
+    }
+
+    return false
+  })
+}
+
 function getSizeInByte(mb) {
   return mb * 0.8 * 1000 * 1000
 }
@@ -29,4 +130,12 @@ function getFileNameExt(fileName, ext = 'pdf') {
   return fileName.replace(/\.[0-9a-zA-Z]+$/, `.${ext}`)
 }
 
-module.exports = { getSizeInByte, getFileName, getCleanFilename, getFileNameExt }
+module.exports = {
+  getSizeInByte,
+  getFileName,
+  getCleanFilename,
+  getFileNameExt,
+  parsePathList,
+  matchesGlobPattern,
+  isPathExcluded,
+}

--- a/test/repo.test.js
+++ b/test/repo.test.js
@@ -96,4 +96,27 @@ describe('RepoBook', () => {
 
     fs.rmSync(tmpDir, { recursive: true, force: true })
   })
+
+  it('excludes files matching exclude_list glob patterns', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'repo-to-pdf-'))
+    const srcDir = path.join(tmpDir, 'src')
+    const generatedDir = path.join(srcDir, 'generated')
+    fs.mkdirSync(generatedDir, { recursive: true })
+
+    fs.writeFileSync(path.join(srcDir, 'app.js'), 'console.log("app")\n')
+    fs.writeFileSync(path.join(srcDir, 'app.test.js'), 'test("app")\n')
+    fs.writeFileSync(path.join(generatedDir, 'bundle.js'), 'console.log("generated")\n')
+    fs.writeFileSync(path.join(tmpDir, 'README.md'), '# Project\n')
+
+    const repoBook = new RepoBook(tmpDir, 'test', Number.MAX_SAFE_INTEGER, null, '**/*.test.js,src/generated/**')
+    const output = repoBook.render()
+
+    expect(output).toContain('app.js')
+    expect(output).toContain('README.md')
+    expect(output).not.toContain('app.test.js')
+    expect(output).not.toContain('generated')
+    expect(output).not.toContain('bundle.js')
+
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
 })

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,0 +1,27 @@
+const { matchesGlobPattern, isPathExcluded } = require('../src/utils')
+
+describe('glob pattern helpers', () => {
+  it('matches standard Unix glob patterns', () => {
+    expect(matchesGlobPattern('app.js', '*.js')).toBe(true)
+    expect(matchesGlobPattern('src/app.js', '*.js')).toBe(false)
+    expect(matchesGlobPattern('src/app.ts', '*.js')).toBe(false)
+    expect(matchesGlobPattern('src/foo.test.js', '**/*.test.js')).toBe(true)
+    expect(matchesGlobPattern('foo.test.js', '*.test.js')).toBe(true)
+    expect(matchesGlobPattern('src/generated/output.js', 'src/generated/**')).toBe(true)
+    expect(matchesGlobPattern('src/generated', 'src/generated/**')).toBe(true)
+    expect(matchesGlobPattern('src/app.js', 'src/?pp.js')).toBe(true)
+    expect(matchesGlobPattern('src/app.js', 'src/[ab]pp.js')).toBe(true)
+  })
+
+  it('excludes paths relative to the repo root', () => {
+    const rootDir = '/repo'
+
+    expect(isPathExcluded('/repo/src/app.test.js', rootDir, ['**/*.test.js'])).toBe(true)
+    expect(isPathExcluded('/repo/app.test.js', rootDir, ['**/*.test.js'])).toBe(true)
+    expect(isPathExcluded('/repo/src/app.js', rootDir, ['**/*.test.js'])).toBe(false)
+    expect(isPathExcluded('/repo/docs/README.md', rootDir, ['docs/**'])).toBe(true)
+    expect(isPathExcluded('/repo/src/app.js', rootDir, ['*.min.js'])).toBe(false)
+    expect(isPathExcluded('/repo/dist/app.min.js', rootDir, ['*.min.js'])).toBe(true)
+    expect(isPathExcluded('/repo/src/app.js', rootDir, ['*.js'])).toBe(true)
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an `exclude_list` option (and `--exclude` CLI flag) to skip files and directories during PDF/ebook generation using standard Unix glob patterns.

## Usage

**CLI:**
```bash
npx repo-to-pdf ./src -x "**/*.test.js,src/generated/**"
```

**API:**
```js
generateEbook('./', 'test.pdf', 'repo-test', {
  exclude_list: '**/*.test.js,src/generated/**',
})
```

`exclude_list` accepts a comma-separated string or an array of patterns.

## Supported glob syntax

- `*` — match any characters except `/`
- `**` — match any characters including `/`
- `?` — match a single character except `/`
- `[abc]` — character class
- Trailing `/**` (e.g. `src/generated/**`) excludes a directory and all contents

Patterns are matched against:
- Paths relative to the input folder (e.g. `src/app.js`)
- Basenames (e.g. `app.js`)
- Individual path segments for extension-style patterns (e.g. `*.min.js`)

Built-in exclusions (`node_modules`, `vendor`) remain unchanged.

## Testing

- Added `test/utils.test.js` for glob matching helpers
- Added integration test in `test/repo.test.js` for excluded files/directories
- All 35 tests pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-007e43ff-45bb-479f-b479-483193a0c42d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-007e43ff-45bb-479f-b479-483193a0c42d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

