### PR TITLE
Add footer options for page numbers and chapter titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   - imitates the HTML/GitHub styling with `highlight.js` syntax highlighting
   - embeds a PDF outline (table of contents) and uses only built-in fonts to keep files small
   - available via `-r native`
+- add `--footer-chapter-title` option to show chapter titles in the footer
+- add `--footer-page-number` option to show page numbers in the footer
 
 ## v0.1.12(2026-06-16)
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ const { generateEbook } = require('repo-to-pdf')
  * @property {string} baseUrl - base url of CSS style files
  * @property {boolean} outline - include PDF outline/bookmarks (default true)
  * @property {number} concurrency - max number of parallel Puppeteer PDF jobs (default auto)
+ * @property {boolean} footerPageNumber - show page numbers in the bottom-right footer with a rule
+ * @property {boolean} footerChapterTitle - show the current section title in the bottom-right footer with a rule
  */
 
 /**
@@ -98,6 +100,14 @@ output format, either pdf, mobi, epub. mobi and epub are generated using calibre
 --no-outline
 disable PDF outline/bookmarks generation (enabled by default)
 # npx repo-to-pdf ../repo --no-outline
+
+--footer-page-number
+show page numbers at the bottom right of each page with a footer rule
+# npx repo-to-pdf ../repo --footer-page-number
+
+--footer-chapter-title
+show the current section title at the bottom right of each page with a footer rule
+# npx repo-to-pdf ../repo --footer-chapter-title
 
 -p, --concurrency [num]
 set max parallel Puppeteer PDF render jobs (auto uses up to 4 cores)

--- a/html5bp/index.html
+++ b/html5bp/index.html
@@ -13,6 +13,7 @@
         <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
         <style>
             {{relaxedCSS}}
+            {{footerCSS}}
         </style>
         <link rel="stylesheet" href="{{baseUrl}}/css/normalize.css">
         <link rel="stylesheet" href="{{baseUrl}}/css/main.css">

--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -18,6 +18,8 @@ program
   .option('-r, --renderer <engine>', '[native|node|wkhtmltopdf|calibre] native(built-in, no deps), node(puppeteer, default), wkhtmltopdf or calibre', 'node')
   .option('-f, --format <ext>', 'output format, pdf|mobi|epub', 'pdf')
   .option('--no-outline', 'disable PDF outlines/bookmarks (default enabled)')
+  .option('--footer-page-number', 'show page numbers at the bottom right with a footer rule')
+  .option('--footer-chapter-title', 'show the current section title at the bottom right with a footer rule')
   .option('-p, --concurrency <num>', 'number of parallel Puppeteer PDF render jobs')
   .option('-c, --calibre [path]', 'path to calibre')
   .option('-b, --baseUrl [url]', 'base url of html folder. By default file:// is used.')
@@ -39,6 +41,8 @@ const calibrePath = program.calibre
 const baseUrl = program.baseUrl
 const outline = program.outline
 const concurrency = program.concurrency
+const footerPageNumber = program.footerPageNumber
+const footerChapterTitle = program.footerChapterTitle
 
 generateEbook(inputFolder, outputFile, title, {
   renderer,
@@ -50,6 +54,8 @@ generateEbook(inputFolder, outputFile, title, {
   baseUrl,
   outline,
   concurrency,
+  footerPageNumber,
+  footerChapterTitle,
 }).catch((error) => {
   console.error(error)
   process.exitCode = 1

--- a/src/html.js
+++ b/src/html.js
@@ -41,6 +41,45 @@ function getRemarkableParser() {
   return mdParser
 }
 
+function buildFooterCSS(options) {
+  const { footerPageNumber, footerChapterTitle } = options
+  if (!footerChapterTitle) {
+    return ''
+  }
+
+  let bottomRight = footerPageNumber ? 'string(chapter, last) " \\007C " counter(page)' : 'string(chapter, last)'
+
+  return `
+    h4[anchor]:has(+ p a[href="#Contents" i]) {
+      string-set: chapter content(text);
+    }
+    @media print {
+      @page {
+        margin-bottom: 72pt;
+        @bottom-left {
+          vertical-align: top;
+          border-top: 0.75pt solid #d8dee4;
+          content: "";
+        }
+        @bottom-center {
+          vertical-align: top;
+          border-top: 0.75pt solid #d8dee4;
+          content: "";
+        }
+        @bottom-right {
+          vertical-align: top;
+          border-top: 0.75pt solid #d8dee4;
+          content: ${bottomRight};
+          font-size: 9pt;
+          color: #6a737d;
+          padding-top: 6pt;
+          text-align: right;
+        }
+      }
+    }
+  `
+}
+
 // => './path/file-1.html'
 function getHTMLFiles(mdString, repoBook, options) {
   const { pdf_size, white_list, device, baseUrl, protocol, renderer, outputFileName, inputFolder } = options
@@ -81,6 +120,7 @@ function getHTMLFiles(mdString, repoBook, options) {
     .replace('{{cssPath}}', protocol + baseUrl + opts.cssPath[device])
     .replace('{{highlightPath}}', protocol + baseUrl + opts.highlightCssPath)
     .replace('{{relaxedCSS}}', opts.relaxedCSS[device])
+    .replace('{{footerCSS}}', buildFooterCSS(options))
     .replace('{{content}}', mdHtml)
 
   if (!repoBook.hasSingleFile()) {
@@ -94,6 +134,9 @@ function checkOptions(options) {
   if (options.outline === undefined) {
     options.outline = true
   }
+
+  options.footerPageNumber = !!options.footerPageNumber
+  options.footerChapterTitle = !!options.footerChapterTitle
 
   if (options.concurrency !== undefined) {
     const concurrency = Number(options.concurrency)
@@ -149,6 +192,8 @@ function checkOptions(options) {
  * @property {string} baseUrl - base url of CSS style files
  * @property {boolean} outline - include PDF outline/bookmarks (default true)
  * @property {number} concurrency - max number of parallel Puppeteer render jobs (default auto)
+ * @property {boolean} footerPageNumber - show page numbers in the bottom-right footer with a rule
+ * @property {boolean} footerChapterTitle - show the current section title in the bottom-right footer with a rule
  */
 
 /**

--- a/src/native.js
+++ b/src/native.js
@@ -21,7 +21,11 @@ function getNativeOutputFile(repoBook, options) {
 // dependency-free generator.
 function renderNativePart(mdString, repoBook, options) {
   const outputFile = getNativeOutputFile(repoBook, options)
-  const buffer = renderMarkdownToPdf(mdString, { outline: options.outline !== false })
+  const buffer = renderMarkdownToPdf(mdString, {
+    outline: options.outline !== false,
+    footerPageNumber: options.footerPageNumber,
+    footerChapterTitle: options.footerChapterTitle,
+  })
   fs.writeFileSync(outputFile, buffer)
   return outputFile
 }

--- a/src/pdf/layout.js
+++ b/src/pdf/layout.js
@@ -43,6 +43,16 @@ const COLORS = {
   bullet: '#24292e',
 }
 
+const FOOTER = {
+  height: 28,
+  ruleOffset: 6,
+  fontSize: 9,
+  textOffset: 8,
+  gap: 8,
+  separatorWidth: 0.5,
+  separatorHeight: 10,
+}
+
 const ASCENT = 0.78
 
 function hexToRgb(hex) {
@@ -127,6 +137,17 @@ class Layout {
     this.outline = []
     this.headingStack = [] // for nested outline building
     this.leftBar = null
+    this.footerPageNumber = !!options.footerPageNumber
+    this.footerChapterTitle = !!options.footerChapterTitle
+    this.currentChapterTitle = ''
+  }
+
+  _hasFooter() {
+    return this.footerPageNumber || this.footerChapterTitle
+  }
+
+  _contentBottom() {
+    return this._hasFooter() ? PAGE.height - MARGIN.bottom - FOOTER.height : PAGE.height - MARGIN.bottom
   }
 
   // --- low level drawing --------------------------------------------------
@@ -165,7 +186,50 @@ class Layout {
 
   // --- pagination ---------------------------------------------------------
 
+  _drawFooter() {
+    if (!this._hasFooter()) {
+      return
+    }
+
+    const footerBottom = PAGE.height - MARGIN.bottom
+    const ruleY = footerBottom - FOOTER.height + FOOTER.ruleOffset
+    this._line(MARGIN.left, ruleY, PAGE.width - MARGIN.right, ruleY, COLORS.rule, 0.75)
+
+    const baseline = footerBottom - FOOTER.textOffset
+    const showChapter = this.footerChapterTitle && this.currentChapterTitle
+    const showPage = this.footerPageNumber
+    if (!showChapter && !showPage) {
+      return
+    }
+
+    let x = PAGE.width - MARGIN.right
+
+    if (showPage) {
+      const pageText = String(this.pageIndex + 1)
+      const pageWidth = measureText(pageText, 'body', FOOTER.fontSize, this.fontManager)
+      x -= pageWidth
+      this._text(x, baseline, pageText, 'body', FOOTER.fontSize, COLORS.quoteText)
+    }
+
+    if (showChapter && showPage) {
+      x -= FOOTER.gap
+      const sepTop = baseline - FOOTER.separatorHeight / 2
+      const sepBottom = baseline + FOOTER.separatorHeight / 2
+      this._line(x, sepTop, x, sepBottom, COLORS.rule, FOOTER.separatorWidth)
+      x -= FOOTER.gap
+    }
+
+    if (showChapter) {
+      const titleWidth = measureText(this.currentChapterTitle, 'body', FOOTER.fontSize, this.fontManager)
+      x -= titleWidth
+      this._text(x, baseline, this.currentChapterTitle, 'body', FOOTER.fontSize, COLORS.quoteText)
+    }
+  }
+
   _newPage() {
+    if (this._hasFooter()) {
+      this._drawFooter()
+    }
     this.doc.addPage(this.ops.join('\n'))
     this.ops = []
     this.y = MARGIN.top
@@ -173,7 +237,7 @@ class Layout {
   }
 
   _ensure(height) {
-    if (this.y + height > PAGE.height - MARGIN.bottom) {
+    if (this.y + height > this._contentBottom()) {
       this._newPage()
       return true
     }
@@ -314,6 +378,9 @@ class Layout {
           }
 
           inToc = false
+          if (isFileHeader) {
+            this.currentChapterTitle = block.text
+          }
           this._heading(block, left, width, { outline: true })
           break
         }
@@ -403,7 +470,7 @@ class Layout {
     }
 
     for (const lineRuns of display) {
-      if (this.y + CODE_LINE > PAGE.height - MARGIN.bottom) {
+      if (this.y + CODE_LINE > this._contentBottom()) {
         finishSegment()
         this._newPage()
         segStart = this.ops.length
@@ -520,7 +587,7 @@ class Layout {
       }
       const rowHeight = maxLines * TABLE_LINE + 2 * padY
 
-      if (this.y + rowHeight > PAGE.height - MARGIN.bottom && this.y > MARGIN.top) {
+      if (this.y + rowHeight > this._contentBottom() && this.y > MARGIN.top) {
         this._newPage()
       }
 
@@ -572,6 +639,9 @@ class Layout {
   }
 
   finish(options = {}) {
+    if (this._hasFooter()) {
+      this._drawFooter()
+    }
     if (this.ops.length > 0 || this.doc.pages.length === 0) {
       this.doc.addPage(this.ops.join('\n'))
       this.ops = []

--- a/src/puppeteer.js
+++ b/src/puppeteer.js
@@ -51,7 +51,7 @@ class HTML2PDF {
 
   async pdf(templatePath, outputPath, options = {}) {
     await this._initializePlugins()
-    const { outline = true } = options
+    const { outline = true, footerPageNumber = false, footerChapterTitle = false } = options
     const puppeteerPage = await this.chrome.newPage()
     await puppeteerPage.setJavaScriptEnabled(false)
 
@@ -62,10 +62,19 @@ class HTML2PDF {
       })
       const pdfOptions = {
         path: outputPath,
-        displayHeaderFooter: false,
+        displayHeaderFooter: footerPageNumber && !footerChapterTitle,
         printBackground: true,
         timeout: DEFAULT_PDF_TIMEOUT_SECONDS * 1000,
         outline,
+      }
+
+      if (footerPageNumber || footerChapterTitle) {
+        pdfOptions.margin = { top: '54px', bottom: '72px', left: '54px', right: '54px' }
+      }
+
+      if (footerPageNumber && !footerChapterTitle) {
+        pdfOptions.footerTemplate =
+          '<div style="width: 100%; font-size: 9px; color: #6a737d; padding: 4px 54px 0; border-top: 0.75px solid #d8dee4; text-align: right;"><span class="pageNumber"></span></div>'
       }
 
       await puppeteerPage.pdf(pdfOptions)

--- a/test/native.test.js
+++ b/test/native.test.js
@@ -119,10 +119,40 @@ describe('syntax highlighter', () => {
 })
 
 describe('layout', () => {
+  function firstPageContent(buffer) {
+    const zlib = require('zlib')
+    const streamStart = buffer.indexOf('stream\n') + 7
+    const streamEnd = buffer.indexOf('\nendstream', streamStart)
+    return zlib.inflateSync(buffer.slice(streamStart, streamEnd)).toString('latin1')
+  }
+
   it('renders markdown to a PDF buffer with a %PDF header', () => {
     const buffer = renderMarkdownToPdf('# Heading\n\nParagraph text.', { outline: true })
     expect(buffer.slice(0, 5).toString('latin1')).toBe('%PDF-')
     expect(buffer.toString('latin1').trimEnd().endsWith('%%EOF')).toBe(true)
+  })
+
+  it('draws page numbers in the footer when enabled', () => {
+    const md = Array.from({ length: 80 }, (_, i) => `Line ${i}`).join('\n\n')
+    const buffer = renderMarkdownToPdf(md, { footerPageNumber: true })
+    const content = firstPageContent(buffer)
+    expect(content).toMatch(/\(1\) Tj/)
+  })
+
+  it('draws chapter titles in the footer when enabled', () => {
+    const md = '#### src/example.js \n[to top](#Contents)\n\n```js\nconst x = 1\n```'
+    const buffer = renderMarkdownToPdf(md, { footerChapterTitle: true })
+    const content = firstPageContent(buffer)
+    expect(content).toContain('src/example.js')
+  })
+
+  it('draws chapter title and page number with a separator when both are enabled', () => {
+    const md = '#### src/example.js \n[to top](#Contents)\n\n```js\nconst x = 1\n```'
+    const buffer = renderMarkdownToPdf(md, { footerPageNumber: true, footerChapterTitle: true })
+    const content = firstPageContent(buffer)
+    expect(content).toContain('src/example.js')
+    expect(content).toMatch(/\(1\) Tj/)
+    expect(content).toMatch(/\d+(?:\.\d+)? w[\s\S]* RG[\s\S]* l S/)
   })
 
   it('embeds CJK and Unicode text with Identity-H fonts', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds two optional footer features for PDF output:

- **`footerPageNumber`** (`--footer-page-number`): page number at the bottom right with a footer rule
- **`footerChapterTitle`** (`--footer-chapter-title`): current section title (file header) at the bottom right with a footer rule

When both are enabled, the native renderer shows `Chapter Title | Page` with a vertical separator between them.

## Implementation

### Native renderer (`src/pdf/layout.js`)
- Reserves footer space below the content area
- Draws a horizontal footer rule spanning the content width
- Tracks the current section title from H4 file headers
- Renders bottom-right footer text with a vertical line separator when both options are on

### Node renderer (Puppeteer)
- Page numbers only: uses Puppeteer `displayHeaderFooter` with a styled footer template
- Chapter titles (with or without page numbers): injects CSS paged-media margin boxes via `buildFooterCSS()` in `html.js`

### CLI / API
- New flags: `--footer-page-number`, `--footer-chapter-title`
- Options are normalized in `checkOptions()` and passed through to all render paths

## Usage

```bash
npx repo-to-pdf ./src -r native --footer-page-number
npx repo-to-pdf ./src -r native --footer-chapter-title
npx repo-to-pdf ./src -r native --footer-page-number --footer-chapter-title
```

```js
generateEbook('./src', 'out.pdf', 'My Book', {
  renderer: 'native',
  footerPageNumber: true,
  footerChapterTitle: true,
})
```

## Testing

- Added layout tests verifying page numbers, chapter titles, and the separator line in native PDF output
- Full test suite passes (35 tests)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e427f353-672e-45af-bee3-aca746adfffe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e427f353-672e-45af-bee3-aca746adfffe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

